### PR TITLE
rk_headset: change "get pin level again" log to debug

### DIFF
--- a/drivers/headset_observe/rk_headset_irq_hook_adc.c
+++ b/drivers/headset_observe/rk_headset_irq_hook_adc.c
@@ -122,7 +122,7 @@ static irqreturn_t headset_interrupt(int irq, void *dev_id)
 	for (i = 0; i < 3; i++) {
 		level = gpio_get_value(pdata->headset_gpio);
 		if (level < 0) {
-			pr_err("%s:get pin level again,pin=%d,i=%d\n",
+			pr_debug("%s:get pin level again,pin=%d,i=%d\n",
 			       __func__, pdata->headset_gpio, i);
 			msleep(1);
 			continue;
@@ -133,7 +133,7 @@ static irqreturn_t headset_interrupt(int irq, void *dev_id)
 		pr_err("%s:get pin level  err!\n", __func__);
 		goto out;
 	} else {
-		pr_err("%s:get pin level again, pin=%d,i=%d\n",
+		pr_debug("%s:get pin level again, pin=%d,i=%d\n",
 		       __func__, pdata->headset_gpio, i);
 	}
 


### PR DESCRIPTION
When headphone is not plugged to rock5b, there are always err logs in dmesg `headset_interrupt:get pin level again, pin=61,i=0`. I change this log from err to debug to avoid it.