### PR TITLE
drm/rockchip: vop2: remove WARN_ON for drm_modeset_is_locked

### DIFF
--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
+++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
@@ -3285,7 +3285,7 @@ static void vop2_crtc_load_lut(struct drm_crtc *crtc)
 	if (!vop2->is_enabled || !vp->lut || !vop2->lut_regs)
 		return;
 
-	if (WARN_ON(!drm_modeset_is_locked(&crtc->mutex)))
+	if (!drm_modeset_is_locked(&crtc->mutex))
 		return;
 
 	if (vop2->version == VOP_VERSION_RK3568) {


### PR DESCRIPTION
This WARN_ON will output a long call trace to kernel log, which is annoying and doesn't mean the display is broken. Just remove it.