### PR TITLE
cma: Enable reserved-memory on orangepi5

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
@@ -69,6 +69,21 @@
 			linux,default-trigger-delay-ms = <0>;
 		};
 	};
+
+	/* If hdmirx node is disabled, delete the reserved-memory node here. */
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		/* Reserve 256MB memory for hdmirx-controller@fdee0000 */
+		cma {
+			compatible = "shared-dma-pool";
+			reusable;
+			reg = <0x0 (256 * 0x100000) 0x0 (256 * 0x100000)>;
+			linux,cma-default;
+		};
+	};
 };
 
 &gmac1 {


### PR DESCRIPTION
Fix the cma_alloc: alloc failed problem.
<img width="913" alt="image" src="https://user-images.githubusercontent.com/6939585/226095922-f26b2346-4242-4444-9bfc-83421c8dbf19.png">
