### PR TITLE
Make PD negotiation faster on rock5b

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
@@ -886,6 +886,7 @@
 			compatible = "usb-c-connector";
 			label = "USB-C";
 			data-role = "dual";
+			faster-pd-negotiation;
 			power-role = "sink";
 			try-power-role = "sink";
 			op-sink-microwatt = <1000000>;

--- a/drivers/usb/typec/tcpm/tcpm.c
+++ b/drivers/usb/typec/tcpm/tcpm.c
@@ -486,6 +486,7 @@ struct tcpm_port {
 	int logbuffer_tail;
 	u8 *logbuffer[LOG_BUFFER_ENTRIES];
 #endif
+	bool faster_pd_negotiation;
 };
 
 struct pd_rx_event {
@@ -4159,7 +4160,7 @@ static void run_state_machine(struct tcpm_port *port)
 		break;
 	case SNK_ATTACH_WAIT:
 		port->debouncing = true;
-		timer_val_msecs = PD_T_CC_DEBOUNCE;
+		timer_val_msecs = port->faster_pd_negotiation ? 100 : PD_T_CC_DEBOUNCE;
 		trace_android_vh_typec_tcpm_get_timer(tcpm_states[SNK_ATTACH_WAIT],
 						      CC_DEBOUNCE, &timer_val_msecs);
 		if ((port->cc1 == TYPEC_CC_OPEN &&
@@ -4317,7 +4318,7 @@ static void run_state_machine(struct tcpm_port *port)
 		if (port->vbus_never_low) {
 			port->vbus_never_low = false;
 			tcpm_set_state(port, SNK_SOFT_RESET,
-				       timer_val_msecs);
+				       port->faster_pd_negotiation ? 100 : timer_val_msecs);
 		} else {
 			tcpm_set_state(port, hard_reset_state(port),
 				       timer_val_msecs);
@@ -4874,7 +4875,7 @@ static void run_state_machine(struct tcpm_port *port)
 			       PD_T_ERROR_RECOVERY);
 		break;
 	case PORT_RESET_WAIT_OFF:
-		timer_val_msecs = PD_T_PS_SOURCE_OFF;
+		timer_val_msecs = port->faster_pd_negotiation ? 100 : PD_T_PS_SOURCE_OFF;
 		trace_android_vh_typec_tcpm_get_timer(tcpm_states[PORT_RESET_WAIT_OFF],
 						      SOURCE_OFF, &timer_val_msecs);
 		tcpm_set_state(port,
@@ -6116,6 +6117,8 @@ sink:
 	port->operating_snk_mw = mw / 1000;
 
 	port->self_powered = fwnode_property_read_bool(fwnode, "self-powered");
+
+	port->faster_pd_negotiation = fwnode_property_read_bool(fwnode, "faster-pd-negotiation");
 
 	/* FRS can only be supported byb DRP ports */
 	if (port->port_type == TYPEC_PORT_DRP) {


### PR DESCRIPTION
Original idea: https://forum.radxa.com/t/a-little-hack-to-make-pd-negotiation-fininsh-earlier/15923
I add a devicetree property `faster-pd-negotiation` to apply this hack.
<details><summary>Without this hack</summary>
<p>

```
[    2.634546] Setting usb_comm capable false
[    2.639207] Setting voltage/current limit 0 mV 0 mA
[    2.639213] polarity 0
[    2.639234] Requesting mux state 0, usb-role 0, orientation 0
[    2.640068] state change INVALID_STATE -> SNK_UNATTACHED [rev1 NONE_AMS]
[    2.640078] CC1: 0 -> 0, CC2: 0 -> 0 [state SNK_UNATTACHED, polarity 0, disconnected]
[    2.640082] 4-0022: registered
[    2.640084] Setting usb_comm capable false
[    2.644739] Setting voltage/current limit 0 mV 0 mA
[    2.644746] polarity 0
[    2.644748] Requesting mux state 0, usb-role 0, orientation 0
[    2.645557] cc:=2
[    2.650971] pending state change PORT_RESET -> PORT_RESET_WAIT_OFF @ 100 ms [rev1 NONE_AMS]
[    2.650976] state change PORT_RESET -> PORT_RESET_WAIT_OFF [delayed 100 ms]
[    2.650980] pending state change PORT_RESET_WAIT_OFF -> SNK_UNATTACHED @ 920 ms [rev1 NONE_AMS]
[    3.571217] state change PORT_RESET_WAIT_OFF -> SNK_UNATTACHED [delayed 920 ms]
[    3.571236] Start toggling
[    3.592277] CC1: 0 -> 0, CC2: 0 -> 5 [state TOGGLING, polarity 0, connected]
[    3.592291] state change TOGGLING -> SNK_ATTACH_WAIT [rev1 NONE_AMS]
[    3.592304] pending state change SNK_ATTACH_WAIT -> SNK_DEBOUNCED @ 200 ms [rev1 NONE_AMS]
[    3.792435] state change SNK_ATTACH_WAIT -> SNK_DEBOUNCED [delayed 200 ms]
[    3.792451] state change SNK_DEBOUNCED -> SNK_ATTACHED [rev1 NONE_AMS]
[    3.792460] polarity 1
[    3.792467] Requesting mux state 1, usb-role 2, orientation 2
[    3.793485] state change SNK_ATTACHED -> SNK_STARTUP [rev1 NONE_AMS]
[    3.793528] state change SNK_STARTUP -> SNK_DISCOVERY [rev3 NONE_AMS]
[    3.793535] Setting voltage/current limit 5000 mV 3000 mA
[    3.793546] vbus=0 charge:=1
[    3.793557] state change SNK_DISCOVERY -> SNK_WAIT_CAPABILITIES [rev3 NONE_AMS]
[    3.798451] pending state change SNK_WAIT_CAPABILITIES -> SNK_SOFT_RESET @ 310 ms [rev3 NONE_AMS]
[    4.108484] state change SNK_WAIT_CAPABILITIES -> SNK_SOFT_RESET [delayed 310 ms]
[    4.108493] AMS SOFT_RESET_AMS start
[    4.108497] state change SNK_SOFT_RESET -> AMS_START [rev3 SOFT_RESET_AMS]
[    4.108499] state change AMS_START -> SOFT_RESET_SEND [rev3 SOFT_RESET_AMS]
[    4.108502] PD TX, header: 0x8d
[    4.115673] PD TX complete, status: 0
[    4.115687] pending state change SOFT_RESET_SEND -> HARD_RESET_SEND @ 60 ms [rev3 SOFT_RESET_AMS]
[    4.123549] PD RX, header: 0x1a3 [1]
[    4.123557] AMS SOFT_RESET_AMS finished
[    4.123559] state change SOFT_RESET_SEND -> SNK_WAIT_CAPABILITIES [rev3 NONE_AMS]
[    4.132396] pending state change SNK_WAIT_CAPABILITIES -> HARD_RESET_SEND @ 310 ms [rev3 NONE_AMS]
[    4.132403] PD RX, header: 0x63a1 [1]
[    4.132407]  PDO 0: type 0, 5000 mV, 3000 mA [E]
[    4.132409]  PDO 1: type 0, 9000 mV, 3000 mA []
[    4.132410]  PDO 2: type 0, 12000 mV, 3000 mA []
[    4.132412]  PDO 3: type 0, 15000 mV, 3000 mA []
[    4.132413]  PDO 4: type 0, 20000 mV, 2250 mA []
[    4.132416]  PDO 5: type 3, 3300-16000 mV, 3000 mA
[    4.132418] state change SNK_WAIT_CAPABILITIES -> SNK_NEGOTIATE_CAPABILITIES [rev3 POWER_NEGOTIATION]
[    4.132422] Setting usb_comm capable false
[    4.132431] cc=2 cc1=0 cc2=5 vbus=0 vconn=sink polarity=1
[    4.132433] Requesting PDO 4: 20000 mV, 2250 mA
[    4.132435] PD TX, header: 0x1282
[    4.140121] PD TX complete, status: 0
[    4.140130] pending state change SNK_NEGOTIATE_CAPABILITIES -> HARD_RESET_SEND @ 60 ms [rev3 POWER_NEGOTIATION]
[    4.143734] PD RX, header: 0x5a3 [1]
[    4.143741] state change SNK_NEGOTIATE_CAPABILITIES -> SNK_TRANSITION_SINK [rev3 POWER_NEGOTIATION]
[    4.143747] Setting standby current 5000 mV @ 500 mA
[    4.143750] Setting voltage/current limit 5000 mV 500 mA
[    4.143758] pending state change SNK_TRANSITION_SINK -> HARD_RESET_SEND @ 500 ms [rev3 POWER_NEGOTIATION]
[    4.177009] PD RX, header: 0x7a6 [1]
[    4.177019] Setting voltage/current limit 20000 mV 2250 mA
[    4.177038] state change SNK_TRANSITION_SINK -> SNK_READY [rev3 POWER_NEGOTIATION]
[    4.177193] AMS POWER_NEGOTIATION finished
[    4.177202] AMS DISCOVER_IDENTITY start
[    4.177207] PD TX, header: 0x148f
[    4.187619] PD TX complete, status: 0
[    4.195866] PD RX, header: 0x49af [1]
[    4.195883] Rx VDM cmd 0xff00a041 type 1 cmd 1 len 4
[    4.195895] AMS DISCOVER_IDENTITY finished
[    4.196014] Identity: 22d9:0002.0002
[    4.196027] AMS DISCOVER_SVIDS start
[    4.196033] PD TX, header: 0x168f
[    4.204621] PD TX complete, status: 0
[    4.209475] PD RX, header: 0xbb0 [1]
[    4.209479] AMS DISCOVER_SVIDS finished
```

</p>
</details>
<details><summary>With this hack</summary>
<p>

```
[    2.617034] Setting usb_comm capable false
[    2.621696] Setting voltage/current limit 0 mV 0 mA
[    2.621702] polarity 0
[    2.621723] Requesting mux state 0, usb-role 0, orientation 0
[    2.622558] state change INVALID_STATE -> SNK_UNATTACHED [rev1 NONE_AMS]
[    2.622569] CC1: 0 -> 0, CC2: 0 -> 0 [state SNK_UNATTACHED, polarity 0, disconnected]
[    2.622573] 4-0022: registered
[    2.622575] Setting usb_comm capable false
[    2.627234] Setting voltage/current limit 0 mV 0 mA
[    2.627240] polarity 0
[    2.627242] Requesting mux state 0, usb-role 0, orientation 0
[    2.628047] cc:=2
[    2.633462] pending state change PORT_RESET -> PORT_RESET_WAIT_OFF @ 100 ms [rev1 NONE_AMS]
[    2.633468] state change PORT_RESET -> PORT_RESET_WAIT_OFF [delayed 100 ms]
[    2.633470] pending state change PORT_RESET_WAIT_OFF -> SNK_UNATTACHED @ 100 ms [rev1 NONE_AMS]
[    2.733500] state change PORT_RESET_WAIT_OFF -> SNK_UNATTACHED [delayed 100 ms]
[    2.733515] Start toggling
[    2.755923] CC1: 0 -> 0, CC2: 0 -> 5 [state TOGGLING, polarity 0, connected]
[    2.755933] state change TOGGLING -> SNK_ATTACH_WAIT [rev1 NONE_AMS]
[    2.755943] pending state change SNK_ATTACH_WAIT -> SNK_DEBOUNCED @ 100 ms [rev1 NONE_AMS]
[    2.855970] state change SNK_ATTACH_WAIT -> SNK_DEBOUNCED [delayed 100 ms]
[    2.855977] state change SNK_DEBOUNCED -> SNK_ATTACHED [rev1 NONE_AMS]
[    2.855982] polarity 1
[    2.855985] Requesting mux state 1, usb-role 2, orientation 2
[    2.856820] state change SNK_ATTACHED -> SNK_STARTUP [rev1 NONE_AMS]
[    2.856839] state change SNK_STARTUP -> SNK_DISCOVERY [rev3 NONE_AMS]
[    2.856843] Setting voltage/current limit 5000 mV 3000 mA
[    2.856850] vbus=0 charge:=1
[    2.856857] state change SNK_DISCOVERY -> SNK_WAIT_CAPABILITIES [rev3 NONE_AMS]
[    2.861549] pending state change SNK_WAIT_CAPABILITIES -> SNK_SOFT_RESET @ 100 ms [rev3 NONE_AMS]
[    2.961606] state change SNK_WAIT_CAPABILITIES -> SNK_SOFT_RESET [delayed 100 ms]
[    2.961621] AMS SOFT_RESET_AMS start
[    2.961627] state change SNK_SOFT_RESET -> AMS_START [rev3 SOFT_RESET_AMS]
[    2.961635] state change AMS_START -> SOFT_RESET_SEND [rev3 SOFT_RESET_AMS]
[    2.961642] PD TX, header: 0x8d
[    2.969465] PD TX complete, status: 0
[    2.969471] pending state change SOFT_RESET_SEND -> HARD_RESET_SEND @ 60 ms [rev3 SOFT_RESET_AMS]
[    2.973016] PD RX, header: 0x1a3 [1]
[    2.973023] AMS SOFT_RESET_AMS finished
[    2.973028] state change SOFT_RESET_SEND -> SNK_WAIT_CAPABILITIES [rev3 NONE_AMS]
[    2.984091] pending state change SNK_WAIT_CAPABILITIES -> HARD_RESET_SEND @ 310 ms [rev3 NONE_AMS]
[    2.984101] PD RX, header: 0x63a1 [1]
[    2.984110]  PDO 0: type 0, 5000 mV, 3000 mA [E]
[    2.984118]  PDO 1: type 0, 9000 mV, 3000 mA []
[    2.984126]  PDO 2: type 0, 12000 mV, 3000 mA []
[    2.984133]  PDO 3: type 0, 15000 mV, 3000 mA []
[    2.984140]  PDO 4: type 0, 20000 mV, 2250 mA []
[    2.984147]  PDO 5: type 3, 3300-16000 mV, 3000 mA
[    2.984154] state change SNK_WAIT_CAPABILITIES -> SNK_NEGOTIATE_CAPABILITIES [rev3 POWER_NEGOTIATION]
[    2.984164] Setting usb_comm capable false
[    2.984183] cc=2 cc1=0 cc2=5 vbus=0 vconn=sink polarity=1
[    2.984191] Requesting PDO 4: 20000 mV, 2250 mA
[    2.984197] PD TX, header: 0x1282
[    2.992085] PD TX complete, status: 0
[    2.992090] pending state change SNK_NEGOTIATE_CAPABILITIES -> HARD_RESET_SEND @ 60 ms [rev3 POWER_NEGOTIATION]
[    2.995705] PD RX, header: 0x5a3 [1]
[    2.995711] state change SNK_NEGOTIATE_CAPABILITIES -> SNK_TRANSITION_SINK [rev3 POWER_NEGOTIATION]
[    2.995724] Setting standby current 5000 mV @ 500 mA
[    2.995729] Setting voltage/current limit 5000 mV 500 mA
[    2.995745] pending state change SNK_TRANSITION_SINK -> HARD_RESET_SEND @ 500 ms [rev3 POWER_NEGOTIATION]
[    3.028544] PD RX, header: 0x7a6 [1]
[    3.028557] Setting voltage/current limit 20000 mV 2250 mA
[    3.028583] state change SNK_TRANSITION_SINK -> SNK_READY [rev3 POWER_NEGOTIATION]
[    3.028855] AMS POWER_NEGOTIATION finished
[    3.028869] AMS DISCOVER_IDENTITY start
[    3.028876] PD TX, header: 0x148f
[    3.038946] PD TX complete, status: 0
[    3.047913] PD RX, header: 0x49af [1]
[    3.047927] Rx VDM cmd 0xff00a041 type 1 cmd 1 len 4
[    3.047942] AMS DISCOVER_IDENTITY finished
[    3.048027] Identity: 22d9:0002.0002
[    3.048040] AMS DISCOVER_SVIDS start
[    3.048047] PD TX, header: 0x168f
[    3.056227] PD TX complete, status: 0
[    3.061060] PD RX, header: 0xbb0 [1]
[    3.061075] AMS DISCOVER_SVIDS finished
```

</p>
</details>
We can save over 1 second time, which should improve PD negotiation loop on rock5b.