### PR TITLE
Rk3588 av1d

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
@@ -169,6 +169,10 @@
 	};
 };
 
+&av1d_mmu {
+	status = "okay";
+};
+
 &i2c0 {
 	status = "okay";
 	pinctrl-names = "default";


### PR DESCRIPTION
Enable missing av1d node on devicetrees of rk3588 boards.