### PR TITLE
arm64: dts: opi5: fix cursor and ap6275p

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
@@ -71,7 +71,6 @@
 		pinctrl-1 = <&uart9_gpios>;
 		BT,reset_gpio    = <&gpio3 RK_PA6 GPIO_ACTIVE_HIGH>;
 		BT,wake_gpio     = <&gpio0 RK_PC6 GPIO_ACTIVE_HIGH>;
-		BT,wake_host_irq = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 
@@ -313,8 +312,7 @@
 		bt_gpio: bt-gpio {
 			rockchip,pins =
 				<3 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>,
-				<0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>,
-				<0 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+				<0 RK_PC6 RK_FUNC_GPIO &pcfg_pull_up>;
 		};
 	};
 

--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
@@ -566,6 +566,7 @@
 
 &vop {
 	status = "okay";
+	disable-win-move;
 	assigned-clocks = <&cru ACLK_VOP>;
 	assigned-clock-rates = <800000000>;
 };
@@ -580,23 +581,27 @@
 
 /* vp0 & vp1 splice for 8K output */
 &vp0 {
+	cursor-win-id=<ROCKCHIP_VOP2_ESMART0>;
 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0)>;
-	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART0>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_CLUSTER0>;
 };
 
 &vp1 {
+	cursor-win-id=<ROCKCHIP_VOP2_ESMART1>;
 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER1 | 1 << ROCKCHIP_VOP2_ESMART1)>;
-	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART1>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_CLUSTER1>;
 };
 
 &vp2 {
+	cursor-win-id=<ROCKCHIP_VOP2_ESMART2>;
 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER2 | 1 << ROCKCHIP_VOP2_ESMART2)>;
-	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART2>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_CLUSTER2>;
 };
 
 &vp3 {
+	cursor-win-id=<ROCKCHIP_VOP2_ESMART3>;
 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER3 | 1 << ROCKCHIP_VOP2_ESMART3)>;
-	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART3>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_CLUSTER3>;
 };
 
 /* Fix tty terminal out of screen, and most dclk of resolutions was not supported in hdmiphy clock from parent clock by default */


### PR DESCRIPTION
1. Fix WiFi and Bluetooth when using the ap6275p on the Orange Pi 5 / 5B.
2. Fix cursor issues (flickering, disappearing, etc.), similar to 4e169d4d1a296f9e85a53376df381b0f45447894 for the Rock 5B.