### PR TITLE
Misc kernel log changes and fix khadas warning

### DIFF
--- a/drivers/clk/clk.c
+++ b/drivers/clk/clk.c
@@ -3420,7 +3420,7 @@ static int __init clk_debug_init(void)
 {
 	struct clk_core *core;
 
-#ifdef CLOCK_ALLOW_WRITE_DEBUGFS
+#if 0
 	pr_warn("\n");
 	pr_warn("********************************************************************\n");
 	pr_warn("**     NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE NOTICE           **\n");

--- a/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
+++ b/drivers/gpu/drm/rockchip/dw_hdmi-rockchip.c
@@ -860,7 +860,7 @@ static void hdmi_select_link_config(struct rockchip_hdmi *hdmi,
 	hdmi->link_cfg.add_func = hdmi->add_func;
 
 	if (!max_frl_rate || (tmdsclk < HDMI20_MAX_RATE && mode.clock < HDMI20_MAX_RATE)) {
-		dev_info(hdmi->dev, "use tmds mode\n");
+		dev_info_once(hdmi->dev, "use tmds mode\n");
 		hdmi->link_cfg.frl_mode = false;
 		return;
 	}

--- a/drivers/misc/khadas-mcu.c
+++ b/drivers/misc/khadas-mcu.c
@@ -536,7 +536,7 @@ static void create_mcu_attrs(void) {
 		return;
 	}
 	for (i = 0; i < ARRAY_SIZE(mcu_class_attrs); i++) {
-		if (class_create_file(g_mcu_data->mcu_class, &mcu_class_attrs[i]));
+		if (class_create_file(g_mcu_data->mcu_class, &mcu_class_attrs[i]))
 			pr_err("create mcu attribute %s fail\n",
 							mcu_class_attrs[i].attr.name);
 	}


### PR DESCRIPTION
A few small patches here, please let me know if there is any issue:
- 374cdd5bf00cf8b37355925e8d7d90c0419c5870 fix khadas compile warning.
- f704e0598236d1e417275408c53195641ba95ed4 report tmds mode once, no reason to be reported multiple times, will only be spam, see [dmesg.log](https://github.com/armbian/linux-rockchip/files/11647808/dmesg.log).
- b2193fb16f6b5a9bdfa601440683bcb2e9d179eb disable CLOCK_ALLOW_WRITE_DEBUGFS notice as previously discussed in #33. 


