### PR TITLE
arm64: dts: add opi5plus device tree overlays

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
@@ -3,6 +3,13 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	orangepi-5-lcd1.dtbo \
 	orangepi-5-lcd2.dtbo \
 	orangepi-5-sata.dtbo \
+	orangepi-5-disable-led.dtbo \
+	orangepi-5-plus-disable-leds.dtbo \
+	orangepi-5-plus-hdmi2-8k.dtbo \
+	orangepi-5-plus-lcd.dtbo \
+	orangepi-5-plus-ov13850.dtbo \
+	orangepi-5-plus-ov13855.dtbo \
+	orangepi-5-plus-sata2.dtbo \
 	rock-5a-hdmi-8k.dtbo \
 	rock-5a-i2c5-rtc-hym8563.dtbo \
 	rock-5a-radxa-camera-4k.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-disable-led.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-disable-led.dts
@@ -1,0 +1,17 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&leds>;
+
+		__overlay__ {
+			status = "okay";
+
+			led@1 {
+				linux,default-trigger = "none";
+			};
+		};
+	};
+};
+

--- a/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-plus-disable-leds.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-plus-disable-leds.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&leds>;
+
+		__overlay__ {
+			status = "okay";
+
+			blue_led@1 {
+				linux,default-trigger = "none";
+			};
+
+			green_led@2 {
+				linux,default-trigger = "none";
+			};
+		};
+	};
+};
+

--- a/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-plus-hdmi2-8k.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-plus-hdmi2-8k.dts
@@ -1,0 +1,37 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&hdmi0_in_vp0>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&hdmi0_in_vp1>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&hdmi1_in_vp0>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&hdmi1_in_vp1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};
+

--- a/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-plus-lcd.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-plus-lcd.dts
@@ -1,0 +1,26 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&dsi1>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&dsi1_panel>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&dsi1_in_vp3>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};
+

--- a/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-plus-ov13850.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-plus-ov13850.dts
@@ -1,0 +1,101 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&csi2_dphy0_hw>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&csi2_dphy0>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&mipi2_csi2>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&rkcif_mipi_lvds2>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@4 {
+		target = <&rkcif_mipi_lvds2_sditf>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@5 {
+		target = <&rkisp0_vir1>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@6 {
+		target = <&i2c3>;
+
+		__overlay__ {
+			status = "okay";
+
+			vm149c-p1@c {
+				status = "okay";
+			};
+
+			ov13850-1@10 {
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@7 {
+		target = <&rkcif>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@8 {
+		target = <&rkcif_mmu>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@9 {
+		target = <&rkisp0>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@10 {
+		target = <&isp0_mmu>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};
+

--- a/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-plus-ov13855.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-plus-ov13855.dts
@@ -1,0 +1,101 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&csi2_dphy0_hw>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&csi2_dphy0>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&mipi2_csi2>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&rkcif_mipi_lvds2>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@4 {
+		target = <&rkcif_mipi_lvds2_sditf>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@5 {
+		target = <&rkisp0_vir1>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@6 {
+		target = <&i2c3>;
+
+		__overlay__ {
+			status = "okay";
+
+			dw9714-p1@c {
+				status = "okay";
+			};
+
+			ov13855-1@36 {
+				status = "okay";
+			};
+		};
+	};
+
+	fragment@7 {
+		target = <&rkcif>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@8 {
+		target = <&rkcif_mmu>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@9 {
+		target = <&rkisp0>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@10 {
+		target = <&isp0_mmu>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};
+

--- a/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-plus-sata2.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-plus-sata2.dts
@@ -1,0 +1,21 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&sata2>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&pcie2x1l1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};
+

--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dtsi
@@ -221,7 +221,7 @@
 		BT,reset_gpio    = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
 		BT,wake_gpio     = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
 		BT,wake_host_irq = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
-		status = "disabled";
+		status = "okay";
 	};
 
 	wireless_wlan: wireless-wlan {
@@ -230,7 +230,7 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&wifi_host_wake_irq>;
 		WIFI,host_wake_irq = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
-		status = "disabled";
+		status = "okay";
 	};
 
 	wifi_disable: wifi-diable-gpio-regulator {


### PR DESCRIPTION
- Orange Pi 5 Plus overlays extracted from Xunlong https://github.com/orangepi-xunlong/linux-orangepi/commit/7e6c3163aa7e58b19730aa2aa259f1bb957cbca0
- Enable wireless WiFi and Bluetooth in the Orange Pi 5 Plus device tree