### PR TITLE
arm64: dts: add opi5b device tree again

### DIFF
--- a/arch/arm64/boot/dts/rockchip/Makefile
+++ b/arch/arm64/boot/dts/rockchip/Makefile
@@ -205,6 +205,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-khadas-edge2.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-nanopi-r6c.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-nanopi-r6s.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-orangepi-5.dtb
+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-orangepi-5b.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-rock-5a.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-tablet-rk806-single-v10.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-tablet-v10.dtb

--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5b.dts
@@ -13,6 +13,10 @@
 	compatible = "rockchip,rk3588s-orangepi-5", "rockchip,rk3588";
 };
 
+&sdhci {
+	status = "okay";
+}
+
 &sfc {
 	status = "disabled";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5b.dts
@@ -15,7 +15,7 @@
 
 &sdhci {
 	status = "okay";
-}
+};
 
 &sfc {
 	status = "disabled";

--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5b.dts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2021 Rockchip Electronics Co., Ltd.
+ *
+ */
+
+/dts-v1/;
+
+#include "rk3588s-orangepi-5.dts"
+
+/ {
+	model = "Orange Pi 5B";
+	compatible = "rockchip,rk3588s-orangepi-5", "rockchip,rk3588";
+};
+
+&sfc {
+	status = "disabled";
+};

--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
@@ -466,7 +466,7 @@
 	max-frequency = <200000000>;
 	mmc-hs400-1_8v;
 	mmc-hs400-enhanced-strobe;
-	status = "disable";
+	status = "disabled";
 };
 
 &sdmmc {

--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
@@ -466,7 +466,7 @@
 	max-frequency = <200000000>;
 	mmc-hs400-1_8v;
 	mmc-hs400-enhanced-strobe;
-	status = "okay";
+	status = "disable";
 };
 
 &sdmmc {


### PR DESCRIPTION
The Orange Pi 5B eMMC conflicts with the SPI flash on the Orange Pi 5. So I propose adding the Orange Pi 5B device tree again to allow the eMMC to be used.