### PR TITLE
Enable HS400 Enhanced Strobe on Rock 5 boards

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
@@ -492,7 +492,7 @@
 	non-removable;
 	max-frequency = <200000000>;
 	mmc-hs400-1_8v;
-	//mmc-hs400-enhanced-strobe;
+	mmc-hs400-enhanced-strobe;
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
@@ -414,7 +414,7 @@
 	non-removable;
 	max-frequency = <200000000>;
 	mmc-hs400-1_8v;
-	/delete-property/ mmc-hs400-enhanced-strobe;
+	mmc-hs400-enhanced-strobe;
 	pinctrl-names = "default";
 	pinctrl-0 = <&emmc_rstnout &emmc_bus8 &emmc_clk &emmc_cmd &emmc_data_strobe>;
 	status = "okay";


### PR DESCRIPTION
This helps with Foresee/Kioxia/Samsung eMMC modules compatibility.