### PR TITLE
Enable hdmirx for opi5plus

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
@@ -323,5 +323,5 @@
 /*** 40 pins ***/
 
 &hdmirx_ctrler {
-	status = "disabled";
+	status = "okay";
 };

--- a/drivers/media/platform/rockchip/hdmirx/rk_hdmirx.c
+++ b/drivers/media/platform/rockchip/hdmirx/rk_hdmirx.c
@@ -1350,9 +1350,7 @@ static void hdmirx_phy_config(struct rk_hdmirx_dev *hdmirx_dev)
 		dev_err(dev, "%s wait pddq ack failed!\n", __func__);
 
 	hdmirx_update_bits(hdmirx_dev, PHY_CONFIG, HDMI_DISABLE, 0);
-	if (wait_reg_bit_status(hdmirx_dev, PHY_STATUS, HDMI_DISABLE_ACK, 0,
-				false, 50))
-		dev_err(dev, "%s wait hdmi disable ack failed!\n", __func__);
+	wait_reg_bit_status(hdmirx_dev, PHY_STATUS, HDMI_DISABLE_ACK, 0, false, 50);
 
 	hdmirx_tmds_clk_ratio_config(hdmirx_dev);
 }
@@ -1489,7 +1487,7 @@ static int hdmirx_wait_lock_and_get_timing(struct rk_hdmirx_dev *hdmirx_dev)
 			break;
 
 		if (!tx_5v_power_present(hdmirx_dev)) {
-			v4l2_err(v4l2_dev, "%s HDMI pull out, return!\n", __func__);
+			//v4l2_err(v4l2_dev, "%s HDMI pull out, return!\n", __func__);
 			return -1;
 		}
 
@@ -2703,7 +2701,7 @@ static irqreturn_t hdmirx_dma_irq_handler(int irq, void *dev_id)
 
 static void hdmirx_audio_interrupts_setup(struct rk_hdmirx_dev *hdmirx_dev, bool en)
 {
-	dev_info(hdmirx_dev->dev, "%s: %d", __func__, en);
+	//dev_info(hdmirx_dev->dev, "%s: %d", __func__, en);
 	if (en) {
 		hdmirx_update_bits(hdmirx_dev, AVPUNIT_1_INT_MASK_N,
 				   DEFRAMER_VSYNC_THR_REACHED_MASK_N,


### PR DESCRIPTION
- enable hdmirx node
- silence hdmirx spam on opi5plus

Xunlong https://github.com/orangepi-xunlong/linux-orangepi/commit/7e6c3163aa7e58b19730aa2aa259f1bb957cbca0 did the same to silence the hdmirx-related spam for the Orange Pi 5 Plus.
Also, see https://github.com/Joshua-Riek/ubuntu-rockchip/issues/190, where this was discussed previously. 
