### PR TITLE
arm64: dts: opi5: fix nvme pcie bandwidth

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
@@ -3,6 +3,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	orangepi-5-lcd1.dtbo \
 	orangepi-5-lcd2.dtbo \
 	orangepi-5-sata.dtbo \
+	orangepi-5-ap6275p.dtbo \
 	orangepi-5-disable-led.dtbo \
 	orangepi-5-plus-disable-leds.dtbo \
 	orangepi-5-plus-hdmi2-8k.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-ap6275p.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/orangepi-5-ap6275p.dts
@@ -1,0 +1,19 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&wireless_bluetooth>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@1 {
+		target = <&wireless_wlan>;
+		__overlay__ {
+			status = "okay";
+			wifi_chip_type = "ap6275p";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dtsi
@@ -71,7 +71,7 @@
 		pinctrl-1 = <&uart9_gpios>;
 		BT,reset_gpio    = <&gpio3 RK_PA6 GPIO_ACTIVE_HIGH>;
 		BT,wake_gpio     = <&gpio0 RK_PC6 GPIO_ACTIVE_HIGH>;
-		status = "okay";
+		status = "disabled";
 	};
 
 	wireless_wlan: wireless-wlan {
@@ -81,7 +81,7 @@
 		pinctrl-0 = <&wifi_host_wake_irq>, <&wifi_poweren_gpio>;
 		WIFI,host_wake_irq = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
 		WIFI,poweren_gpio = <&gpio0 RK_PD0 GPIO_ACTIVE_HIGH>;
-		status = "okay";
+		status = "disabled";
 	};
 
 	vbus5v0_typec: vbus5v0-typec {

--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5b.dts
@@ -20,3 +20,11 @@
 &sfc {
 	status = "disabled";
 };
+
+&wireless_bluetooth {
+	status = "okay";
+};
+
+&wireless_wlan {
+	status = "okay";
+};


### PR DESCRIPTION
Having the wireless and bluetooth nodes enabled on the opi5 conflict with PCIe lowering the available bandwidth when using an NVMe SSD. This pr will disable the wireless and bluetooth nodes by default for the opi5, and add an overlay to enable the nodes if desired. I discussed this with @efectn on Discord.

This was brought to my attention from the issue https://github.com/Joshua-Riek/ubuntu-rockchip/issues/195.