### PR TITLE
A few small miscellaneous patches

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
@@ -20,9 +20,9 @@
 
 / {
 	aliases {
-		mmc0 = &sdmmc;
-		mmc1 = &sdio;
-		mmc2 = &sdhci;
+		mmc0 = &sdhci;
+		mmc1 = &sdmmc;
+		mmc2 = &sdio;
 	};
 
 	chosen: chosen {

--- a/drivers/gpu/drm/rockchip/dw-dp.c
+++ b/drivers/gpu/drm/rockchip/dw-dp.c
@@ -2686,7 +2686,7 @@ static ssize_t dw_dp_aux_transfer(struct drm_dp_aux *aux,
 
 	status = wait_for_completion_timeout(&dp->complete, timeout);
 	if (!status) {
-		dev_err(dp->dev, "timeout waiting for AUX reply\n");
+		//dev_err(dp->dev, "timeout waiting for AUX reply\n");
 		return -ETIMEDOUT;
 	}
 

--- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
@@ -453,12 +453,6 @@ static int dwmac4_add_hw_vlan_rx_fltr(struct net_device *dev,
 	if (vid > 4095)
 		return -EINVAL;
 
-	if (hw->promisc) {
-		netdev_err(dev,
-			   "Adding VLAN in promisc mode not supported\n");
-		return -EPERM;
-	}
-
 	/* Single Rx VLAN Filter */
 	if (hw->num_vlan == 1) {
 		/* For single VLAN filter, VID 0 means VLAN promiscuous */
@@ -507,12 +501,6 @@ static int dwmac4_del_hw_vlan_rx_fltr(struct net_device *dev,
 				      __be16 proto, u16 vid)
 {
 	int i, ret = 0;
-
-	if (hw->promisc) {
-		netdev_err(dev,
-			   "Deleting VLAN in promisc mode not supported\n");
-		return -EPERM;
-	}
 
 	/* Single Rx VLAN Filter */
 	if (hw->num_vlan == 1) {


### PR DESCRIPTION
Hello again, I have a few more small patches below:
- 969e6b9d876e67a7436d8cee338af672d2fd69cc arm64: dts: nanopir6: use proper mmc aliases
- 1d4de75e0b5b2fe19a9eab065956f5f58ffff356 drm/rockchip: dw-dp: suppress "timeout waiting for AUX reply" spam
  - This tends to be more noticeable on cli images and spam the tty after some time.
  - https://github.com/Joshua-Riek/ubuntu-rockchip/discussions/240
- 0faf730545679a33292b72e36b818cd17a2432e2 ethernet: dwmac4: fix VLAN in promisc mode not supported
  - https://forum.armbian.com/topic/26518-network-bridge-fails-to-initialize-vlan-in-promisc-mode-not-supported
  - https://github.com/Joshua-Riek/ubuntu-rockchip/issues/213