### PR TITLE
mixtile: Blade 3: enable i2s5_8ch & i2s7_8ch for hdmi audio

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-blade3-v101-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blade3-v101-linux.dts
@@ -271,6 +271,14 @@
 		     &i2s0_sdo0>;
 };
 
+&i2s7_8ch {
+	status = "okay";
+};
+
+&i2s5_8ch {
+	status = "okay";
+};
+
 &iep {
 	status = "okay";
 };


### PR DESCRIPTION
Tested as working by @NicoD-SBC
