### PR TITLE
fix indiedroid wifi DTS by removing WIFI,poweren_gpio

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-9tripod-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-9tripod-linux.dts
@@ -304,7 +304,6 @@
 		pinctrl-names = "default";
 		pinctrl-0 = <&wifi_host_wake_irq>, <&wifi_poweren_gpio>;
 		WIFI,host_wake_irq = <&gpio0 RK_PA0 GPIO_ACTIVE_HIGH>;
-		WIFI,poweren_gpio =  <&gpio0 RK_PC7 GPIO_ACTIVE_LOW>;
 		rockchip,grf = <&sys_grf>;
 		status = "okay";
 	};


### PR DESCRIPTION
9tripod device tree looking for a wifi switch, when we don't use on indiedroid... this device tree is only used for indiedroid.. removed line