### PR TITLE
Fix NanoPi R6 USB3 Issue

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
@@ -636,7 +636,7 @@
 };
 
 &usbdrd_dwc3_0 {
-	dr_mode = "otg";
+	dr_mode = "host";
 	extcon = <&u2phy0>;
 	status = "okay";
 };


### PR DESCRIPTION
check:
- https://github.com/Joshua-Riek/ubuntu-rockchip/issues/258
- https://forum.armbian.com/topic/29273-regression-usb-30-port-not-working-with-kernel-510160/