### PR TITLE
arm64: dts: blade3: add sata2 overlay for mini pcie port

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
@@ -30,6 +30,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rock-5b-rpi-camera-v2.dtbo \
 	rock-5b-radxa-camera-4k.dtbo \
 	rock-5b-sata.dtbo \
+	mixtile-blade3-sata2.dtbo \
 	rockchip-rk3588-opp-oc-24ghz.dtbo \
 	rk3588-can0-m0.dtbo \
 	rk3588-can1-m0.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlay/mixtile-blade3-sata2.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/mixtile-blade3-sata2.dts
@@ -1,0 +1,20 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&pcie2x1l1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&sata2>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
The Mixtile Blade 3 has a Mini PCIe port, and its position on the board makes it perfect for an mSATA SSD. So here is an overlay to enable SATA2 instead of PCIe.