### PR TITLE
arm64: dts: h88k: enable pcie2x1l2

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-hinlink-h88k.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-hinlink-h88k.dts
@@ -708,6 +708,11 @@
 	status = "okay";
 };
 
+&pcie2x1l2 {
+	reset-gpios = <&gpio4 RK_PA5 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+};
+
 &pcie30phy {
 	rockchip,pcie30-phymode = <PHY_MODE_PCIE_AGGREGATION>;
 	status = "okay";
@@ -896,10 +901,6 @@
 &saradc {
 	status = "okay";
 	vref-supply = <&avcc_1v8_s0>;
-};
-
-&sata0 {
-	status = "okay";
 };
 
 &sdhci {


### PR DESCRIPTION
Hinlink H88K has all pcie2x1 on their new board: https://hinlink.yuque.com/org-wiki-hinlink-xqepck/doc_cn/geqw769v53opnqlg
`pcie2x1l2` is for a 2.5G R8125 ethernet.
Old board with sata0 can use overlay like `rock-5a-sata.dts`.