### PR TITLE
arm64: dts: nanopct6: remove fspim1 pin definitions

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
@@ -520,25 +520,6 @@
 		};
 	};
 
-	fspi {
-		/omit-if-no-ref/
-		fspim1_pins: fspim1-pins {
-			rockchip,pins =
-				/* fspi_clk_m1 */
-				<2 RK_PB3 2 &pcfg_pull_up_drv_level_2>,
-				/* fspi_cs0n_m1 */
-				<2 RK_PB4 2 &pcfg_pull_up_drv_level_2>,
-				/* fspi_d0_m1 */
-				<2 RK_PA6 2 &pcfg_pull_up_drv_level_2>,
-				/* fspi_d1_m1 */
-				<2 RK_PA7 2 &pcfg_pull_up_drv_level_2>,
-				/* fspi_d2_m1 */
-				<2 RK_PB0 2 &pcfg_pull_up_drv_level_2>,
-				/* fspi_d3_m1 */
-				<2 RK_PB1 2 &pcfg_pull_up_drv_level_2>;
-		};
-	};
-
 	headphone {
 		hp_det: hp-det {
 			rockchip,pins = <1 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>;


### PR DESCRIPTION
Hello, I have a fix for my previous pr #78, as `/dev/mtdblock0` would still not appear. I read the schematics wrong, and the fspim1 pin definitions must be removed.

I finally got a T6 with working SPI and eMMC, so I can confirm this patch will allow for `/dev/mtdblock0` to show as expected.