### PR TITLE
add ODROID-M1 (`rk3568`, from vendor 4.19.y sources)

### DIFF
--- a/arch/arm64/boot/dts/rockchip/Makefile
+++ b/arch/arm64/boot/dts/rockchip/Makefile
@@ -149,6 +149,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-nvr-demo-v10-linux.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-nvr-demo-v10-linux-spi-nand.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-nvr-demo-v12-linux.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-nvr-demo-v12-linux-spi-nand.dtb
+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-odroid-m1.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-radxa-e25.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-rock-3a.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-toybrick-sd0-android.dtb

--- a/arch/arm64/boot/dts/rockchip/rk3568-odroid-m1.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-odroid-m1.dts
@@ -1,0 +1,231 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2021 Hardkernel Co., Ltd.
+ *
+ */
+
+/dts-v1/;
+
+#include "rk3568-odroid.dtsi"
+#include "rk3568-linux.dtsi"
+
+/ {
+	model = "Hardkernel ODROID-M1";
+	/delete-node/ chosen;
+
+	aliases {
+		serial0 = &uart1;
+		serial1 = &uart0;
+		i2c0 = &i2c3;
+		i2c3 = &i2c0;
+	};
+
+	pcie30_avdd0v9: pcie30-avdd0v9 {
+		compatible = "regulator-fixed";
+		regulator-name = "pcie30_avdd0v9";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <900000>;
+		regulator-max-microvolt = <900000>;
+		vin-supply = <&vcc3v3_sys>;
+	};
+
+	pcie30_avdd1v8: pcie30-avdd1v8 {
+		compatible = "regulator-fixed";
+		regulator-name = "pcie30_avdd1v8";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		vin-supply = <&vcc3v3_sys>;
+	};
+
+	vcc3v3_pcie: gpio-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc3v3_pcie";
+		enable-active-high;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		gpio = <&gpio4 RK_PA7 GPIO_ACTIVE_HIGH>;
+		startup-delay-us = <5000>;
+		vin-supply = <&dc_12v>;
+	};
+};
+
+&can0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&can0m0_pins>;
+	status = "disabled";
+};
+
+&combphy0_us {
+	status = "okay";
+};
+
+&combphy1_usq {
+	status = "okay";
+};
+
+&combphy2_psq {
+	status = "okay";
+};
+
+&gpio0 {
+	gpio-line-names =
+		/* GPIO0_A */
+		"", "", "", "", "", "", "", "",
+		/* GPIO0_B */
+		"", "", "",
+		"PIN_28", /* GPIO0_B3 */
+		"PIN_27", /* GPIO0_B4 */
+		"PIN_33", /* GPIO0_B5 */
+		"PIN_7", /* GPIO0_B6 */
+		"",
+		/* GPIO0_C */
+		"PIN_11", /* GPIO0_C0 */
+		"PIN_13", /* GPIO0_C1 */
+		"", "", "", "", "", "",
+		/* GPIO0_D */
+		"", "", "", "", "", "", "", "";
+};
+
+&gpio1 {
+	gpio-line-names =
+		/* GPIO1_A */
+		"", "", "", "", "", "", "", "",
+		/* GPIO1_B */
+		"", "", "", "", "", "", "", "",
+		/* GPIO1_C */
+		"", "", "", "", "", "", "", "",
+		/* GPIO1_D */
+		"", "", "", "", "", "", "", "";
+};
+
+&gpio2 {
+	gpio-line-names =
+		/* GPIO2_A */
+		"", "", "", "", "", "", "", "",
+		/* GPIO2_B */
+		"", "", "", "", "", "", "", "",
+		/* GPIO2_C */
+		"", "", "", "", "", "", "", "",
+		/* GPIO2_D */
+		"PIN_21", /* GPIO2_D0 */
+		"PIN_19", /* GPIO2_D1 */
+		"PIN_24", /* GPIO2_D2 */
+		"PIN_23", /* GPIO2_D3 */
+		"", "", "", "";
+};
+
+&gpio3 {
+	gpio-line-names =
+		/* GPIO3_A */
+		"", "", "", "", "", "", "", "",
+		/* GPIO3_B */
+		"", "",
+		"PIN_15", /* GPIO3_B2 */
+		"", "",
+		"PIN_5",  /* GPIO3_B5 */
+		"PIN_3",  /* GPIO3_B6 */
+		"",
+		/* GPIO3_C */
+		"", "", "", "", "", "",
+		"PIN_16", /* GPIO3_C6 */
+		"PIN_18", /* GPIO3_C7 */
+		/* GPIO3_D */
+		"PIN_12", /* GPIO3_D0 */
+		"PIN_22", /* GPIO3_D1 */
+		"PIN_26", /* GPIO3_D2 */
+		"PIN_32", /* GPIO3_D3 */
+		"PIN_36", /* GPIO3_D4 */
+		"PIN_35", /* GPIO3_D5 */
+		"PIN_8",  /* GPIO3_D6 */
+		"PIN_10"; /* GPIO3_D7 */
+};
+
+&gpio4 {
+	gpio-line-names =
+		/* GPIO4_A */
+		"", "", "", "", "", "", "", "",
+		/* GPIO4_B */
+		"", "", "", "", "", "",
+		"PIN_31", /* GPIO4_B6 */
+		"",
+		/* GPIO4_C */
+		"",
+		"PIN_29", /* GPIO4_C1 */
+		"", "", "",
+		"", "", "",
+		/* GPIO4_D */
+		"", "", "", "", "", "", "", "";
+};
+
+&hdmi_sound {
+	simple-audio-card,name = "ODROID-M1-HDMI";
+	/delete-property/ rockchip,jack-det;
+};
+
+&i2c3 {
+	status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c3m1_xfer>;
+};
+
+&pcie30phy {
+	status = "okay";
+};
+
+&pcie3x2 {
+	reset-gpios = <&gpio2 RK_PD6 GPIO_ACTIVE_HIGH>;
+	vpcie3v3-supply = <&vcc3v3_pcie>;
+	status = "okay";
+};
+
+&pwm1 {
+	status = "disabled";
+	pinctrl-0 = <&pwm1m1_pins>;
+};
+
+&pwm2 {
+	status = "disabled";
+	pinctrl-0 = <&pwm2m1_pins>;
+};
+
+&reserved_memory {
+	pcie3x2@80900000{
+		reg = <0x0 0x80900000 0x0 0x100000>;
+	};
+};
+
+&rk809_sound {
+	simple-audio-card,name = "ODROID-M1-FRONT";
+};
+
+&sata2 {
+	status = "okay";
+};
+
+&sfc {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&fspi_pins>;
+};
+
+&spi0 {
+	status = "disabled";
+
+	pinctrl-0 = <&spi0m1_pins>;
+	pinctrl-1 = <&spi0m1_pins_hs>;
+	num_chipselect = <1>;
+
+	cs-gpios = <&gpio2 RK_PD2 GPIO_ACTIVE_LOW>;
+};
+
+&uart1 {
+	status = "disabled";
+	dma-names = "tx", "rx";
+	/* uart1 uart1-with-ctsrts */
+	pinctrl-0 = <&uart1m1_xfer>;
+	pinctrl-1 = <&uart1m1_xfer &uart1m1_ctsn &uart1m1_rtsn>;
+};

--- a/arch/arm64/boot/dts/rockchip/rk3568-odroid.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3568-odroid.dtsi
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2021 Hardkernel Co., Ltd.
+ *
+ */
+
+/dts-v1/;
+
+#include "rk3568.dtsi"
+#include "rk3568-evb.dtsi"
+
+/ {
+	/delete-node/ adc-keys;
+	/delete-node/ nandc@fe330000;
+	/delete-node/ sdio-pwrseq;
+	/delete-node/ vcc3v3-lcd0-n;
+	/delete-node/ vcc3v3-lcd1-n;
+	/delete-node/ wireless-bluetooth;
+	/delete-node/ wireless-wlan;
+
+	leds: leds {
+		power_led: power {
+			gpios = <&gpio0 RK_PC6 GPIO_ACTIVE_LOW>;
+			linux,default-trigger = "default-on";
+		};
+		work_led: work {
+			gpios = <&gpio0 RK_PB7 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	rk_headset: rk-headset {
+		compatible = "rockchip_headset";
+		headset_gpio = <&gpio0 RK_PB0 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&hp_det>;
+	};
+
+	rk3568-gpiomem {
+		compatible = "rockchip,rk3568-gpiomem";
+		reg = <0x0 0xfd660000 0x0 0x1000>;
+		status = "okay";
+	};
+
+	rk809_sound: rk809-sound {
+		status = "okay";
+		compatible = "simple-audio-card";
+		simple-audio-card,format = "i2s";
+		simple-audio-card,hp-det-gpio = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
+		simple-audio-card,name = "rockchip,rk809-codec";
+		simple-audio-card,widgets = "Headphones", "Headphones Jack";
+		simple-audio-card,mclk-fs = <256>;
+		simple-audio-card,cpu {
+			sound-dai = <&i2s1_8ch>;
+		};
+		simple-audio-card,codec {
+			sound-dai = <&rk809_codec>;
+		};
+	};
+};
+
+&gmac0 {
+	phy-mode = "rgmii";
+	clock_in_out = "output";
+
+	snps,reset-gpio = <&gpio3 RK_PB7 GPIO_ACTIVE_LOW>;
+	snps,reset-active-low;
+	/* Reset time is 20ms, 100ms for rtl8211f */
+	snps,reset-delays-us = <0 20000 100000>;
+
+	assigned-clocks = <&cru SCLK_GMAC0_RX_TX>, <&cru SCLK_GMAC0>;
+	assigned-clock-parents = <&cru SCLK_GMAC0_RGMII_SPEED>, <&cru CLK_MAC0_2TOP>;
+	assigned-clock-rates = <0>, <125000000>;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&gmac0_miim
+		&gmac0_tx_bus2
+		&gmac0_rx_bus2
+		&gmac0_rgmii_clk
+		&gmac0_rgmii_bus>;
+
+	tx_delay = <0x4f>;
+	rx_delay = <0x2d>;
+
+	phy-handle = <&rgmii_phy0>;
+	status = "okay";
+};
+
+&i2c1 {
+	status = "disabled";
+
+	/delete-node/ gt1x@14;
+};
+
+&i2c2 {
+	status = "disabled";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c2m1_xfer>;
+};
+
+&i2c5 {
+	status = "disabled";
+
+	/delete-node/ mxc6655xa@15;
+};
+
+&mdio0 {
+	rgmii_phy0: phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0x0>;
+
+		interrupt-parent = <&gpio0>;
+		interrupts = <RK_PC5 IRQ_TYPE_LEVEL_LOW>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&ethernet_irq>;
+	};
+};
+
+&pinctrl {
+	can_pins {
+		mcp2515_int_pins: mcp2515_int_pins {
+			rockchip,pins = <0 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+	ethernet {
+		ethernet_irq: ethernet-irq {
+			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+	};
+};
+
+&pinctrl {
+	/delete-node/ mxc6655xa;
+	/delete-node/ touch;
+	/delete-node/ wifi-enable-h;
+	/delete-node/ wireless-bluetooth;
+
+	fspi {
+		fspi_pins: fspi-pins {
+			rockchip,pins =
+				/* fspi_clk */
+				<1 RK_PD0 1 &pcfg_pull_none>,
+				/* fspi_cs0n */
+				<1 RK_PD3 1 &pcfg_pull_none>,
+				/* fspi_d0 */
+				<1 RK_PD1 1 &pcfg_pull_none>;
+		};
+	};
+
+	headphone {
+		hp_det: hp-det {
+			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_down>;
+		};
+	};
+};
+
+&pmu_io_domains {
+	vccio4-supply = <&vcc_1v8>;
+};
+
+&pwm3 {
+	status = "okay";
+
+	compatible = "rockchip,remotectl-pwm";
+	remote_pwm_id = <3>;
+	handle_cpu_id = <1>;
+	remote_support_psci = <0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm3_pins>;
+
+	ir_key1 {
+		rockchip,usercode = <0x4db2>;
+		rockchip,key_table =
+			<0x23	KEY_POWER>,
+			<0x77	KEY_MUTE>,
+			<0x7d	KEY_HOME>,
+			<0x31	KEY_ENTER>,
+			<0x35	KEY_UP>,
+			<0x66	KEY_LEFT>,
+			<0x3e	KEY_RIGHT>,
+			<0x2d	KEY_DOWN>,
+			<0x3a	KEY_MENU>,
+			<0x65	KEY_BACK>,
+			<0x7e	KEY_VOLUMEDOWN>,
+			<0x7f	KEY_VOLUMEUP>;
+	};
+};
+
+&pwm7 {
+	compatible = "rockchip,rk3568-pwm", "rockchip,rk3328-pwm";
+	pinctrl-names = "active";
+	pinctrl-0 = <&pwm7_pins>;
+
+	status = "disabled";
+
+	/delete-property/ remote_pwm_id;
+	/delete-property/ handle_cpu_id;
+	/delete-property/ remote_support_psci;
+	/delete-node/ ir_key1;
+	/delete-node/ ir_key2;
+	/delete-node/ ir_key3;
+};
+
+&rknpu_mmu {
+	status = "disabled";
+};
+
+&rng {
+	status = "okay";
+};
+
+&sdhci {
+	pinctrl-0 = <&emmc_bus8
+		&emmc_clk
+		&emmc_cmd
+		&emmc_datastrobe
+		&emmc_rstnout>;
+	pinctrl-names = "default";
+
+	mmc-hs200-1_8v;
+	cap-mmc-hw-reset;
+};
+
+&video_phy0 {
+	status = "okay";
+};
+
+&hdmi_sound {
+	compatible = "simple-audio-card";
+	simple-audio-card,format = "i2s";
+	simple-audio-card,mclk-fs = <128>;
+	simple-audio-card,name = "rockchip,hdmi";
+	status = "okay";
+	rockchip,jack-det;
+
+	simple-audio-card,cpu {
+		sound-dai = <&i2s0_8ch>;
+	};
+	simple-audio-card,codec {
+		sound-dai = <&hdmi>;
+	};
+};
+
+&rk809_sound {
+	status = "okay";
+	compatible = "simple-audio-card";
+	simple-audio-card,format = "i2s";
+	simple-audio-card,mclk-fs = <256>;
+	simple-audio-card,name = "rockchip,rk809-codec";
+	simple-audio-card,hp-det-gpio = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
+	simple-audio-card,widgets = "Headphones", "Headphone Jack";
+
+	simple-audio-card,cpu {
+		sound-dai = <&i2s1_8ch>;
+	};
+	simple-audio-card,codec {
+		sound-dai = <&rk809_codec>;
+	};
+};
+
+&rk809_codec {
+	#sound-dai-cells = <0>;
+	compatible = "rockchip,rk809-codec", "rockchip,rk817-codec";
+	clocks = <&cru I2S1_MCLKOUT>;
+	clock-names = "mclk";
+	assigned-clocks = <&cru I2S1_MCLKOUT>, <&cru I2S1_MCLK_TX_IOE>;
+	assigned-clock-rates = <12288000>;
+	assigned-clock-parents = <&cru I2S1_MCLKOUT_TX>, <&cru I2S1_MCLKOUT_TX>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2s1m0_mclk &hp_det>;
+	hp-volume = <20>;
+	spk-volume = <3>;
+	status = "okay";
+};
+
+&rk_headset {
+	status = "disabled";
+};
+
+&spdif_8ch {
+	status = "disabled";
+};
+
+&spdif_out {
+	status = "disabled";
+};

--- a/arch/arm64/boot/dts/rockchip/rk3568-odroid.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3568-odroid.dtsi
@@ -6,6 +6,7 @@
 
 /dts-v1/;
 
+#include <dt-bindings/display/rockchip_vop.h>
 #include "rk3568.dtsi"
 #include "rk3568-evb.dtsi"
 
@@ -284,4 +285,18 @@
 
 &spdif_out {
 	status = "disabled";
+};
+
+// Suggested by amazingfate: https://github.com/armbian/build/pull/4794#issuecomment-1423606844
+// "add these properties to node &gpu to support panfrost driver"
+&gpu {
+	clock-names = "gpu", "bus";
+	interrupt-names = "gpu", "mmu", "job";
+};
+
+// Suggested by amazingfate: https://github.com/armbian/build/pull/4794#issuecomment-1423606844
+// "add &vp0 node to support video output"
+&vp0 {
+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0)>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART0>;
 };


### PR DESCRIPTION
#### add ODROID-M1 (`rk3568`, straight copy from vendor 4.19.y sources) to rkr5.1

Might be fun for a desktop, working video encoder/transcoding, if anyone finds this booting & fixes it properly?

[AF pointed me to this possibility in february'23](https://github.com/armbian/build/pull/4794#issuecomment-1423606844). 
Since I've the ODROID-M1 on the bench for working on Kwiboo's u-boot, [UMS goodness, and de-infestation from Petitboot](https://github.com/armbian/build/pull/5606) (plug), I figured why not.

It boots, UART/PCI/NVMe/SD/eMMC/USB2/USB3/OTG works, (text console) video output on HDMI, rest is untested (eg desktop/gpu/vpu).

Interestingly, the UDC (micro-usb OTG) works -- I doesn't on mainline kernel, and the simple dr change to otg worked on Kwiboo's 23.10-rc2 u-boot but not in the mainline kernel. 

here's the (ANSI, for redness) `dmesg`: https://paste.next.armbian.com/akenesudid -- quite a lot of reds.

- taken from https://github.com/hardkernel/linux/tree/odroidm1-4.19.y sha1 89b88ec44cb98ec17b8460cc3c0127fcb1f7b159 (which should be an ancestor of this rkr5.1 branch too)
- added the infamous delete chosen
- moved stuff HK did to common rk3568-linux.dtsi to their own odroid common dtsi -- not sure if there are other rk odroids.
- change `RK_GPIO0` -> `0`
- @amazingfate's gpu & vp tips from back when
