### PR TITLE
arm64: dts: 9tripod: audio fixes

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-9tripod-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-9tripod-linux.dts
@@ -136,6 +136,16 @@
 		};
 	};
 
+	dp0_sound: dp0-sound {
+		status = "okay";
+		compatible = "rockchip,hdmi";
+		rockchip,card-name= "rockchip-dp0";
+		rockchip,mclk-fs = <512>;
+		rockchip,cpu = <&spdif_tx2>;
+		rockchip,codec = <&dp0 1>;
+		rockchip,jack-det;
+	};
+
 	minipcie_power: minipcie-power {
 		compatible = "regulator-fixed";
 		regulator-name = "minipcie_power";
@@ -947,6 +957,10 @@
 &route_dp0 {
 	status = "okay";
 	connect = <&vp2_out_dp0>;
+};
+
+&spdif_tx2 {
+	status = "okay";
 };
 
 &route_dsi0 {

--- a/arch/arm64/boot/dts/rockchip/rk3588s-9tripod-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-9tripod-linux.dts
@@ -123,17 +123,12 @@
 
 	hdmi0_sound: hdmi0-sound {
 		status = "okay";
-		compatible = "simple-audio-card";
-		simple-audio-card,format = "i2s";
-		simple-audio-card,mclk-fs = <128>;
-		simple-audio-card,name = "rockchip,hdmi0";
+		compatible = "rockchip,hdmi";
+		rockchip,mclk-fs = <128>;
+		rockchip,card-name = "rockchip-hdmi0";
+		rockchip,cpu = <&i2s5_8ch>;
+		rockchip,codec = <&hdmi0>;
 		rockchip,jack-det;
-		simple-audio-card,cpu {
-			sound-dai = <&i2s5_8ch>;
-		};
-		simple-audio-card,codec {
-			sound-dai = <&hdmi0>;
-		};
 	};
 
 	dp0_sound: dp0-sound {


### PR DESCRIPTION
Hello! Two small patches here for the Indiedroid Nova. 
- 2d721fa465108b16b17c090a347c76644f481298 Enable sound for the USB-C display port.
- 3880fdd2a27aa0374c8a3b0ce2057db8d8507922 Use the proper rockchip,hdmi driver for hdmi0 sound, not the simple-audio-card driver.