### PR TITLE
gpu: drm: rockchip: suppress unsupported format modifier spam

### DIFF
--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
+++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
@@ -2259,7 +2259,7 @@ static bool rockchip_vop2_mod_supported(struct drm_plane *plane, u32 format, u64
 		return true;
 
 	if (!rockchip_afbc(plane, modifier) && !rockchip_tiled(plane, modifier)) {
-		DRM_ERROR("Unsupported format modifier 0x%llx\n", modifier);
+		//DRM_ERROR("Unsupported format modifier 0x%llx\n", modifier);
 
 		return false;
 	}


### PR DESCRIPTION
Hello! Here is a patch to suppress kernel logs from being spammed by "Unsupported format modifier" errors. It will typically happen when watching YouTube or video playback with MPV. 

example dmesg with spam: [dmesg.txt](https://github.com/armbian/linux-rockchip/files/12563881/dmesg.txt)

ref: https://github.com/Joshua-Riek/ubuntu-rockchip/issues/86