### PR TITLE
arm64: dts: rockchip: change sound card names for pulseaudio ucm2 compatibility

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-armsom-w3.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-armsom-w3.dts
@@ -151,7 +151,7 @@
 	dp0_sound: dp0-sound {
 		status = "okay";
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp0";
+		rockchip,card-name = "rockchip-dp0";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx2>;
 		rockchip,codec = <&dp0 1>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-blade3-v101-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blade3-v101-linux.dts
@@ -45,7 +45,7 @@
 		rockchip,format = "i2s";
 		rockchip,bitclock-master = <&hdmirx_ctrler>;
 		rockchip,frame-master = <&hdmirx_ctrler>;
-		rockchip,card-name = "rockchip,hdmiin";
+		rockchip,card-name = "rockchip-hdmiin";
 		rockchip,cpu = <&i2s7_8ch>;
 		rockchip,codec = <&hdmirx_ctrler 0>;
 		rockchip,jack-det;
@@ -64,7 +64,7 @@
 	dp0_sound: dp0-sound {
 		status = "okay";
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp0";
+		rockchip,card-name = "rockchip-dp0";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx2>;
 		rockchip,codec = <&dp0 1>;
@@ -74,7 +74,7 @@
 	dp1_sound: dp1-sound {
 		status = "okay";
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp1";
+		rockchip,card-name = "rockchip-dp1";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx5>;
 		rockchip,codec = <&dp1 1>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-blueberry-edge-v10.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blueberry-edge-v10.dtsi
@@ -48,7 +48,7 @@
 		rockchip,format = "i2s";
 		rockchip,bitclock-master = <&hdmirx_ctrler>;
 		rockchip,frame-master = <&hdmirx_ctrler>;
-		rockchip,card-name = "rockchip,hdmiin";
+		rockchip,card-name = "rockchip-hdmiin";
 		rockchip,cpu = <&i2s7_8ch>;
 		rockchip,codec = <&hdmirx_ctrler 0>;
 		rockchip,jack-det;

--- a/arch/arm64/boot/dts/rockchip/rk3588-blueberry-edge-v12.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blueberry-edge-v12.dtsi
@@ -66,7 +66,7 @@
 		rockchip,format = "i2s";
 		rockchip,bitclock-master = <&hdmirx_ctrler>;
 		rockchip,frame-master = <&hdmirx_ctrler>;
-		rockchip,card-name = "rockchip,hdmiin";
+		rockchip,card-name = "rockchip-hdmiin";
 		rockchip,cpu = <&i2s7_8ch>;
 		rockchip,codec = <&hdmirx_ctrler 0>;
 		rockchip,jack-det;

--- a/arch/arm64/boot/dts/rockchip/rk3588-blueberry-edge-v14.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blueberry-edge-v14.dtsi
@@ -66,7 +66,7 @@
 		rockchip,format = "i2s";
 		rockchip,bitclock-master = <&hdmirx_ctrler>;
 		rockchip,frame-master = <&hdmirx_ctrler>;
-		rockchip,card-name = "rockchip,hdmiin";
+		rockchip,card-name = "rockchip-hdmiin";
 		rockchip,cpu = <&i2s7_8ch>;
 		rockchip,codec = <&hdmirx_ctrler 0>;
 		rockchip,jack-det;

--- a/arch/arm64/boot/dts/rockchip/rk3588-blueberry-minipc.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blueberry-minipc.dtsi
@@ -31,7 +31,7 @@
 		rockchip,format = "i2s";
 		rockchip,bitclock-master = <&hdmirx_ctrler>;
 		rockchip,frame-master = <&hdmirx_ctrler>;
-		rockchip,card-name = "rockchip,hdmiin";
+		rockchip,card-name = "rockchip-hdmiin";
 		rockchip,cpu = <&i2s7_8ch>;
 		rockchip,codec = <&hdmirx_ctrler 0>;
 		rockchip,jack-det;

--- a/arch/arm64/boot/dts/rockchip/rk3588-blueberry.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blueberry.dtsi
@@ -38,7 +38,7 @@
 	dp0_sound: dp0-sound {
 		status = "disabled";
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp0";
+		rockchip,card-name = "rockchip-dp0";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx2>;
 		rockchip,codec = <&dp0 1>;
@@ -48,7 +48,7 @@
 	dp1_sound: dp1-sound {
 		status = "disabled";
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp1";
+		rockchip,card-name = "rockchip-dp1";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx5>;
 		rockchip,codec = <&dp1 1>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-fxblox-rk1.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-fxblox-rk1.dts
@@ -103,7 +103,7 @@
 	dp0_sound: dp0-sound {
 		status = "okay";
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp0";
+		rockchip,card-name = "rockchip-dp0";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx2>;
 		rockchip,codec = <&dp0 1>;
@@ -113,7 +113,7 @@
 	dp1_sound: dp1-sound {
 		status = "okay";
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp1";
+		rockchip,card-name = "rockchip-dp1";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx5>;
 		rockchip,codec = <&dp1 1>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-hinlink-h88k.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-hinlink-h88k.dts
@@ -33,7 +33,7 @@
 
 	dp0_sound: dp0-sound {
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp0";
+		rockchip,card-name = "rockchip-dp0";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx2>;
 		rockchip,codec = <&dp0 1>;
@@ -80,7 +80,7 @@
 		rockchip,format = "i2s";
 		rockchip,bitclock-master = <&hdmirx_ctrler>;
 		rockchip,frame-master = <&hdmirx_ctrler>;
-		rockchip,card-name = "rockchip,hdmiin";
+		rockchip,card-name = "rockchip-hdmiin";
 		rockchip,cpu = <&i2s7_8ch>;
 		rockchip,codec = <&hdmirx_ctrler 0>;
 		rockchip,jack-det;

--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
@@ -36,7 +36,7 @@
 	dp0_sound: dp0-sound {
 		status = "okay";
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp0";
+		rockchip,card-name = "rockchip-dp0";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx2>;
 		rockchip,codec = <&dp0 1>;
@@ -112,7 +112,7 @@
 		compatible = "simple-audio-card";
 		simple-audio-card,format = "i2s";
 		simple-audio-card,mclk-fs = <128>;
-		simple-audio-card,name = "rockchip,hdmi1";
+		simple-audio-card,name = "rockchip-hdmi1";
 
 		simple-audio-card,cpu {
 			sound-dai = <&i2s6_8ch>;
@@ -129,7 +129,7 @@
 		rockchip,format = "i2s";
 		rockchip,bitclock-master = <&hdmirx_ctrler>;
 		rockchip,frame-master = <&hdmirx_ctrler>;
-		rockchip,card-name = "rockchip,hdmiin";
+		rockchip,card-name = "rockchip-hdmiin";
 		rockchip,cpu = <&i2s7_8ch>;
 		rockchip,codec = <&hdmirx_ctrler 0>;
 		rockchip,jack-det;

--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dtsi
@@ -28,7 +28,7 @@
 	es8388_sound: es8388-sound {
 		status = "okay";
 		compatible = "rockchip,multicodecs-card";
-		rockchip,card-name = "rockchip,es8388";
+		rockchip,card-name = "rockchip-es8388";
 		hp-det-gpio = <&gpio1 RK_PD3 GPIO_ACTIVE_HIGH>;
 		io-channels = <&saradc 3>;
 		io-channel-names = "adc-detect";
@@ -68,7 +68,7 @@
 		rockchip,format = "i2s";
 		rockchip,bitclock-master = <&hdmirx_ctrler>;
 		rockchip,frame-master = <&hdmirx_ctrler>;
-		rockchip,card-name = "rockchip,hdmiin";
+		rockchip,card-name = "rockchip-hdmiin";
 		rockchip,cpu = <&i2s7_8ch>;
 		rockchip,codec = <&hdmirx_ctrler 0>;
 		rockchip,jack-det;

--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi.dtsi
@@ -87,7 +87,7 @@
 	dp0_sound: dp0-sound {
 		status = "disabled";
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp0";
+		rockchip,card-name = "rockchip-dp0";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx2>;
 		rockchip,codec = <&dp0 1>;
@@ -97,7 +97,7 @@
 	dp1_sound: dp1-sound {
 		status = "disabled";
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp1";
+		rockchip,card-name = "rockchip-dp1";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx5>;
 		rockchip,codec = <&dp1 1>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
@@ -114,7 +114,7 @@
 	dp0_sound: dp0-sound {
 		status = "okay";
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp0";
+		rockchip,card-name = "rockchip-dp0";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx2>;
 		rockchip,codec = <&dp0 1>;
@@ -222,7 +222,7 @@
 		rockchip,format = "i2s";
 		rockchip,bitclock-master = <&hdmirx_ctrler>;
 		rockchip,frame-master = <&hdmirx_ctrler>;
-		rockchip,card-name = "rockchip,hdmiin";
+		rockchip,card-name = "rockchip-hdmiin";
 		rockchip,cpu = <&i2s7_8ch>;
 		rockchip,codec = <&hdmirx_ctrler 0>;
 		rockchip,jack-det;

--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dtsi
@@ -69,7 +69,7 @@
 	dp0_sound: dp0-sound {
 		status = "disabled";
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp0";
+		rockchip,card-name = "rockchip-dp0";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx2>;
 		rockchip,codec = <&dp0 1>;
@@ -122,7 +122,7 @@
 		compatible = "simple-audio-card";
 		simple-audio-card,format = "i2s";
 		simple-audio-card,mclk-fs = <128>;
-		simple-audio-card,name = "rockchip,hdmi0";
+		simple-audio-card,name = "rockchip-hdmi0";
 
 		simple-audio-card,cpu {
 			sound-dai = <&i2s5_8ch>;

--- a/arch/arm64/boot/dts/rockchip/rk3588s-lubancat-4.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-lubancat-4.dts
@@ -210,7 +210,7 @@
 	dp0_sound: dp0-sound {
 		status = "okay";
 		compatible = "rockchip,hdmi";
-		rockchip,card-name= "rockchip,dp0";
+		rockchip,card-name = "rockchip-dp0";
 		rockchip,mclk-fs = <512>;
 		rockchip,cpu = <&spdif_tx2>;
 		rockchip,codec = <&dp0 1>;

--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
@@ -34,7 +34,7 @@
 		compatible = "simple-audio-card";
 		simple-audio-card,format = "i2s";
 		simple-audio-card,mclk-fs = <128>;
-		simple-audio-card,name = "rockchip,hdmi0";
+		simple-audio-card,name = "rockchip-hdmi0";
 
 		simple-audio-card,cpu {
 			sound-dai = <&i2s5_8ch>;


### PR DESCRIPTION
Pulseaudio ucm2 configs can't handle the character "," or long names. So here is a patch to modify the sound card names by replacing the character "," with "-".

ref: c5e85bafa0c26003714d31feacc7bf46d28660f2