### PR TITLE
Add GPIO nodes and use rockchip,hdmi driver for NanoPi R6 and NanoPC T6 

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
@@ -109,17 +109,11 @@
 
 	hdmi1_sound: hdmi1-sound {
 		status = "disabled";
-		compatible = "simple-audio-card";
-		simple-audio-card,format = "i2s";
-		simple-audio-card,mclk-fs = <128>;
-		simple-audio-card,name = "rockchip-hdmi1";
-
-		simple-audio-card,cpu {
-			sound-dai = <&i2s6_8ch>;
-		};
-		simple-audio-card,codec {
-			sound-dai = <&hdmi1>;
-		};
+		compatible = "rockchip,hdmi";
+		rockchip,mclk-fs = <128>;
+		rockchip,card-name = "rockchip-hdmi1";
+		rockchip,cpu = <&i2s6_8ch>;
+		rockchip,codec = <&hdmi1>;
 	};
 
 	hdmiin_sound: hdmiin-sound {

--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
@@ -721,3 +721,61 @@
 	clock-names = "hdmi0_phy_pll", "hdmi1_phy_pll";
 };
 
+&pwm5 {
+	pinctrl-0 = <&pwm5m1_pins>;
+	status = "okay";
+};
+
+&pwm9 {
+	pinctrl-0 = <&pwm9m0_pins>;
+	status = "okay";
+};
+
+&spi0 {
+	num-cs = <1>;
+	pinctrl-0 = <&spi0m2_cs0 &spi0m2_pins>;
+	status = "disabled";
+
+	spidev0: spidev@0 {
+		compatible = "rockchip,spidev";
+		reg = <0>;
+		spi-max-frequency = <5000000>;
+		status = "disabled";
+	};
+};
+
+&spi4 {
+	num-cs = <1>;
+	pinctrl-0 = <&spi4m1_cs0 &spi4m1_pins>;
+	status = "disabled";
+};
+
+&uart0 {
+	pinctrl-0 = <&uart0m0_xfer>;
+	status = "disabled";
+};
+
+&uart3 {
+	pinctrl-0 = <&uart3m1_xfer>;
+	status = "disabled";
+};
+
+&uart4 {
+	pinctrl-0 = <&uart4m2_xfer>;
+	status = "disabled";
+};
+
+&uart6 {
+	pinctrl-0 = <&uart6m1_xfer>;
+	status = "okay";
+};
+
+&uart7 {
+	pinctrl-0 = <&uart7m2_xfer>;
+	status = "disabled";
+};
+
+&uart8 {
+	pinctrl-0 = <&uart8m1_xfer>;
+	status = "disabled";
+};

--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
@@ -31,17 +31,11 @@
 
 	hdmi0_sound: hdmi0-sound {
 		status = "disabled";
-		compatible = "simple-audio-card";
-		simple-audio-card,format = "i2s";
-		simple-audio-card,mclk-fs = <128>;
-		simple-audio-card,name = "rockchip-hdmi0";
-
-		simple-audio-card,cpu {
-			sound-dai = <&i2s5_8ch>;
-		};
-		simple-audio-card,codec {
-			sound-dai = <&hdmi0>;
-		};
+		compatible = "rockchip,hdmi";
+		rockchip,mclk-fs = <128>;
+		rockchip,card-name = "rockchip-hdmi0";
+		rockchip,cpu = <&i2s5_8ch>;
+		rockchip,codec = <&hdmi0>;
 	};
 
 	vcc5v0_sys: vcc5v0-sys {

--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
@@ -697,3 +697,25 @@
 	clocks = <&hdptxphy_hdmi_clk0>;
 	clock-names = "hdmi0_phy_pll";
 };
+
+&spi0 {
+	pinctrl-0 = <&spi0m2_cs0 &spi0m2_pins>;
+	status = "disabled";
+
+	spidev0: spidev@0 {
+		compatible = "rockchip,spidev";
+		reg = <0>;
+		spi-max-frequency = <10000000>;
+		status = "disabled";
+	};
+};
+
+&uart4 {
+	pinctrl-0 = <&uart4m2_xfer>;
+	status = "disabled";
+};
+
+&uart5 {
+	pinctrl-0 = <&uart5m1_xfer>;
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6c.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6c.dts
@@ -26,3 +26,13 @@
 &pcie2x1l2 {
 	/delete-node/ pcie@40;
 };
+
+&pwm0 {
+	pinctrl-0 = <&pwm0m2_pins>;
+	status = "okay";
+};
+
+&pwm1 {
+	pinctrl-0 = <&pwm1m2_pins>;
+	status = "okay";
+};


### PR DESCRIPTION
- arm64: dts: rockchip: add GPIO nodes for NanoPi R6 and NanoPC T6 
  - cherry picked from: https://github.com/friendlyarm/kernel-rockchip/commit/5549a0faea4e87d7cfb34880753f34b374d30999
- arm64: dts: rockchip: use rockchip,hdmi driver for NanoPi R6 and NanoPC T6
