### PR TITLE
arm64: dts: mekotronics: enable avsd; add missing sound-dai-cells to v12's hdmirx_ctrler

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-blueberry-edge-v12.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blueberry-edge-v12.dtsi
@@ -342,6 +342,7 @@
 &hdmirx_ctrler {
 	status = "okay";
 
+	#sound-dai-cells = <1>;
 	/* Effective level used to trigger HPD: 0-low, 1-high */
 	hpd-trigger-level = <1>;
 	hdmirx-det-gpios = <&gpio1 RK_PD5 GPIO_ACTIVE_LOW>;   //gpio1_d5

--- a/arch/arm64/boot/dts/rockchip/rk3588-blueberry.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blueberry.dtsi
@@ -84,6 +84,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &CPU_SLEEP {
 	status = "disabled";
 };


### PR DESCRIPTION
#### arm64: dts: mekotronics: enable avsd; add missing sound-dai-cells to v12's hdmirx_ctrler

- source: vendor drop `blueberry_edge_patch_230810`