### PR TITLE
arm64: dts: rockchip: rk3568: remove opp-supported-hw from gpu_opp_table

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3568.dtsi
@@ -1339,13 +1339,13 @@
 		interrupts = <GIC_SPI 39 IRQ_TYPE_LEVEL_HIGH>,
 			     <GIC_SPI 41 IRQ_TYPE_LEVEL_HIGH>,
 			     <GIC_SPI 40 IRQ_TYPE_LEVEL_HIGH>;
-		interrupt-names = "GPU", "MMU", "JOB";
+		interrupt-names = "gpu", "mmu", "job";
 
 		upthreshold = <40>;
 		downdifferential = <10>;
 
 		clocks = <&scmi_clk 1>, <&cru CLK_GPU>;
-		clock-names = "clk_mali", "clk_gpu";
+		clock-names = "gpu", "bus";
 		power-domains = <&power RK3568_PD_GPU>;
 		#cooling-cells = <2>;
 		operating-points-v2 = <&gpu_opp_table>;
@@ -1388,22 +1388,22 @@
 
 		/* RK3568 && RK3568M gpu OPPs */
 		opp-200000000 {
-			opp-supported-hw = <0xfb 0xffff>;
+			//opp-supported-hw = <0xfb 0xffff>;
 			opp-hz = /bits/ 64 <200000000>;
 			opp-microvolt = <850000 850000 1000000>;
 		};
 		opp-300000000 {
-			opp-supported-hw = <0xfb 0xffff>;
+			//opp-supported-hw = <0xfb 0xffff>;
 			opp-hz = /bits/ 64 <300000000>;
 			opp-microvolt = <850000 850000 1000000>;
 		};
 		opp-400000000 {
-			opp-supported-hw = <0xfb 0xffff>;
+			//opp-supported-hw = <0xfb 0xffff>;
 			opp-hz = /bits/ 64 <400000000>;
 			opp-microvolt = <850000 850000 1000000>;
 		};
 		opp-600000000 {
-			opp-supported-hw = <0xfb 0xffff>;
+			//opp-supported-hw = <0xfb 0xffff>;
 			opp-hz = /bits/ 64 <600000000>;
 			opp-microvolt = <900000 900000 1000000>;
 			opp-microvolt-L0 = <900000 900000 1000000>;
@@ -1412,7 +1412,7 @@
 			opp-microvolt-L3 = <850000 850000 1000000>;
 		};
 		opp-700000000 {
-			opp-supported-hw = <0xfb 0xffff>;
+			//opp-supported-hw = <0xfb 0xffff>;
 			opp-hz = /bits/ 64 <700000000>;
 			opp-microvolt = <950000 950000 1000000>;
 			opp-microvolt-L0 = <950000 950000 1000000>;
@@ -1421,7 +1421,7 @@
 			opp-microvolt-L3 = <875000 875000 1000000>;
 		};
 		opp-800000000 {
-			opp-supported-hw = <0xf9 0xffff>;
+			//opp-supported-hw = <0xf9 0xffff>;
 			opp-hz = /bits/ 64 <800000000>;
 			opp-microvolt = <1000000 1000000 1000000>;
 			opp-microvolt-L0 = <1000000 1000000 1000000>;


### PR DESCRIPTION
Panfrost can't get loaded on rk3568 with rkr6 branch.
Opp tables is not enabled at https://github.com/armbian/linux-rockchip/blob/rk-5.10-rkr6/drivers/opp/of.c#L440-L441.
Since we use panfrost driver so `opp-supported-hw` is useless, deleting it will make panfrost work.
I also changed gpu `interrupt-names` and `clock-names` in rk3568.dtsi for panfrost so work like https://github.com/armbian/linux-rockchip/blob/rk-5.10-rkr6/arch/arm64/boot/dts/rockchip/rk3566-orangepi-3b.dts#L341-L342 is not needed  in the future.