### PR TITLE
video: rockchip: rga3: fix compatibility with legacy global alpha config

### DIFF
--- a/drivers/video/rockchip/rga3/rga2_reg_info.c
+++ b/drivers/video/rockchip/rga3/rga2_reg_info.c
@@ -2108,7 +2108,7 @@ static void rga_cmd_to_rga2_cmd(struct rga_scheduler_t *scheduler,
 					req->alpha_config.bg_global_alpha_value = 0xff;
 				}
 			} else {
-				req->alpha_config.bg_global_alpha_value = 0xff;
+				req->alpha_config.fg_global_alpha_value = 0xff;
 				req->alpha_config.bg_global_alpha_value = 0xff;
 			}
 

--- a/drivers/video/rockchip/rga3/rga3_reg_info.c
+++ b/drivers/video/rockchip/rga3/rga3_reg_info.c
@@ -1662,7 +1662,7 @@ static void rga_cmd_to_rga3_cmd(struct rga_req *req_rga, struct rga3_req *req)
 					req->alpha_config.bg_global_alpha_value = 0xff;
 				}
 			} else {
-				req->alpha_config.bg_global_alpha_value = 0xff;
+				req->alpha_config.fg_global_alpha_value = 0xff;
 				req->alpha_config.bg_global_alpha_value = 0xff;
 			}
 


### PR DESCRIPTION
Fixes a RGA regression in **rkr6** 7291693, which broke compatibility with **librga 1.9.x and older** when using DST over blend/composite and premultiplied alpha.

It's a typo.
```c
req->alpha_config.bg_global_alpha_value = 0xff; // should be `fg` foreground instead of `bg` background
req->alpha_config.bg_global_alpha_value = 0xff; // duplicated
```

When `req_rga->feature.global_alpha_en` is false, it means the API version of userspace librga is 1.9.x and older. And this fix is to make sure it falls back to the legacy behavior.

In addition, the source code of librga 1.10 is not yet available to the public at this point.