### PR TITLE
arm64: dts: turing-rk1: remove usb controller and phy nodes for usb c

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
@@ -532,27 +532,3 @@
 	pinctrl-0 = <&uart9m0_xfer>;
 	status = "okay";
 };
-
-&u2phy0 {
-	status = "okay";
-};
-
-&u2phy0_otg {
-	status = "okay";
-};
-
-&usbdp_phy0 {
-	status = "okay";
-};
-
-&usbdp_phy0_u3 {
-	status = "okay";
-};
-
-&usbdrd3_0 {
-	status = "okay";
-};
-
-&usbdrd_dwc3_0 {
-	status = "okay";
-};


### PR DESCRIPTION
These nodes are required for USB C, which the Turing RK1 does not have. So they should be removed.

Thanks!