### PR TITLE
arm64: dts: turing-rk1: configure extcon attribute

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
@@ -554,5 +554,6 @@
 };
 
 &usbdrd_dwc3_0 {
+	extcon = <&u2phy0>;
 	status = "okay";
 };


### PR DESCRIPTION
Configure the extcon attribute to support software switching Device/Host mode for OTG.

Thanks!