### PR TITLE
ethernet: realtek: r8125: stop rss spamming kernel logs

### DIFF
--- a/drivers/net/ethernet/realtek/r8125/r8125_rss.c
+++ b/drivers/net/ethernet/realtek/r8125/r8125_rss.c
@@ -88,7 +88,7 @@ int rtl8125_get_rxnfc(struct net_device *dev, struct ethtool_rxnfc *cmd,
         struct rtl8125_private *tp = netdev_priv(dev);
         int ret = -EOPNOTSUPP;
 
-        netif_info(tp, drv, tp->dev, "rss get rxnfc\n");
+        netif_dbg(tp, drv, tp->dev, "rss get rxnfc\n");
 
         if (!(dev->features & NETIF_F_RXHASH))
                 return ret;


### PR DESCRIPTION
Simple patch to silence some excessive kernel logging for the r8125.

Source: https://github.com/Joshua-Riek/ubuntu-rockchip/issues/402#issuecomment-1787704472