### PR TITLE
arm64: dts: turing-rk1: use HS200 mode for eMMC

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
@@ -438,15 +438,13 @@
 	status = "okay";
 };
 
+/* HS400 mode cause io errors on production units */
 &sdhci {
 	bus-width = <8>;
+	no-mmc-hs400;
 	no-sdio;
 	no-sd;
 	non-removable;
-	max-frequency = <200000000>;
-	mmc-hs400-1_8v;
-	mmc-hs400-enhanced-strobe;
-	full-pwr-cycle-in-suspend;
 	status = "okay";
 };
 


### PR DESCRIPTION
On the production RK1 boards, a new eMMC chip was selected. For some reason, it causes I/O errors when writing data to the eMMC. I spent a lot of time trying to debug this but could not find a proper solution. So for now use HS200 mode to avoid the problem.