### PR TITLE
arm64: dts: turing-rk1: fix USB 2.0 PHY0 OTG

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
@@ -536,15 +536,20 @@
 };
 
 &u2phy0_otg {
+	rockchip,sel-pipe-phystatus;
 	status = "okay";
 };
 
 &usbdp_phy0 {
-	status = "okay";
+	status = "disabled";
+};
+
+&usbdp_phy0_dp {
+	status = "disabled";
 };
 
 &usbdp_phy0_u3 {
-	status = "okay";
+	status = "disabled";
 };
 
 &usbdrd3_0 {
@@ -552,6 +557,10 @@
 };
 
 &usbdrd_dwc3_0 {
+	dr_mode = "host";
+	phys = <&u2phy0_otg>;
+	phy-names = "usb2-phy";
+	maximum-speed = "high-speed";
 	extcon = <&u2phy0>;
 	status = "okay";
 };


### PR DESCRIPTION
Simple patch here to fix the USB 2.0 OTG port on the Turing RK1.

Thanks!