### PR TITLE
arm64: dts: turing-rk1: fix HS400 I/O errors

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
@@ -544,13 +544,15 @@
 	status = "okay";
 };
 
-/* HS400 mode cause io errors on production units */
 &sdhci {
 	bus-width = <8>;
-	no-mmc-hs400;
 	no-sdio;
 	no-sd;
 	non-removable;
+	max-frequency = <200000000>;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
+	full-pwr-cycle-in-suspend;
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
@@ -538,6 +538,12 @@
 			rockchip,pins = <2 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
+
+	emmc {
+		emmc_data_strobe: emmc-data-strobe {
+			rockchip,pins = <2 RK_PA2 1 &pcfg_pull_down>;
+		};
+	};
 };
 
 &pwm0 {
@@ -553,6 +559,8 @@
 	mmc-hs400-1_8v;
 	mmc-hs400-enhanced-strobe;
 	full-pwr-cycle-in-suspend;
+	pinctrl-names = "default";
+	pinctrl-0 = <&emmc_data_strobe>;
 	status = "okay";
 };
 


### PR DESCRIPTION
For HS400 to work with the RK1's eMMC, `emmc_data_strobe` needs to be pulled down.