### PR TITLE
arm64: dts: add new board hinlink-hnas

### DIFF
--- a/arch/arm64/boot/dts/rockchip/Makefile
+++ b/arch/arm64/boot/dts/rockchip/Makefile
@@ -158,6 +158,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-evb8-lp4-v10.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-evb8-lp4-v10-linux.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-hinlink-h66k.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-hinlink-h68k.dtb
+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-hinlink-hnas.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-iotest-ddr3-v10.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-iotest-ddr3-v10-linux.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-nvr-demo-v10.dtb

--- a/arch/arm64/boot/dts/rockchip/rk3568-hinlink-hnas.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-hinlink-hnas.dts
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2020 Rockchip Electronics Co., Ltd.
+ *
+ */
+
+/dts-v1/;
+
+#include "rk3568-hinlink-h6xk.dtsi"
+
+/ {
+	model = "HINLINK HNAS";
+	compatible = "hinlink,hnas", "rockchip,rk3568";
+
+	aliases {
+		ethernet0 = &rtl8125_1;
+		ethernet1 = &rtl8125_2;
+	};
+
+	fan0: pwm-fan {
+		compatible = "pwm-fan";
+		#cooling-cells = <2>;
+		cooling-levels = <8 39 70 100 131 162 193 224 255>;
+		pwms = <&pwm0 0 10000 0>;
+	};
+
+	hdd_leds {
+		led_hdd1: led-hdd1 {
+			pinctrl-names = "default";
+			pinctrl-0 = <&led_hdd1_pin>;
+			label = "led:hdd1";
+			gpios = <&gpio3 RK_PB6 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_hdd2: led-hdd2 {
+			pinctrl-names = "default";
+			pinctrl-0 = <&led_hdd2_pin>;
+			label = "led:hdd2";
+			gpios = <&gpio3 RK_PB5 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_hdd3: led-hdd3 {
+			pinctrl-names = "default";
+			pinctrl-0 = <&led_hdd3_pin>;
+			label = "led:hdd3";
+			gpios = <&gpio3 RK_PB2 GPIO_ACTIVE_HIGH>;
+		};
+
+		led_hdd4: led-hdd4 {
+			pinctrl-names = "default";
+			pinctrl-0 = <&led_hdd4_pin>;
+			label = "led:hdd4";
+			gpios = <&gpio3 RK_PB1 GPIO_ACTIVE_HIGH>;
+		};
+	};
+
+	sata_pm_power: sata-pm-power {
+		compatible = "regulator-fixed";
+		regulator-name = "sata_pm_power";
+		regulator-enable-ramp-delay = <1000000>;
+		regulator-always-on;
+		regulator-boot-on;
+
+		enable-active-high;
+		gpio = <&gpio4 RK_PB0 GPIO_ACTIVE_HIGH>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&sata_pm_power_en>;
+		vin-supply = <&vcc3v3_sys>;
+	};
+
+	sata_pm_reset: sata-pm-reset {
+		compatible = "regulator-fixed";
+		regulator-name = "sata_pm_reset";
+		regulator-enable-ramp-delay = <1000000>;
+		regulator-always-on;
+		regulator-boot-on;
+
+		enable-active-high;
+		gpio = <&gpio4 RK_PA7 GPIO_ACTIVE_HIGH>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&sata_pm_reset_en>;
+		vin-supply = <&vcc3v3_sys>;
+	};
+
+	sata_hdd_power: sata-hdd-power {
+		compatible = "regulator-fixed";
+		regulator-name = "sata_hdd_power";
+		regulator-enable-ramp-delay = <1000000>;
+		regulator-always-on;
+		regulator-boot-on;
+
+		enable-active-high;
+		gpio = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&sata_hdd_power_en>;
+		vin-supply = <&vcc5v0_sys>;
+	};
+};
+
+&pinctrl {
+	hdd-leds {
+		led_hdd1_pin: led-hdd1-pin {
+			rockchip,pins = <3 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		led_hdd2_pin: led-hdd2-pin {
+			rockchip,pins = <3 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		led_hdd3_pin: led-hdd3-pin {
+			rockchip,pins = <3 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		led_hdd4_pin: led-hdd4-pin {
+			rockchip,pins = <3 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
+	sata-pm {
+		sata_pm_power_en: sata-pm-power-en {
+			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_down>;
+		};
+
+		sata_pm_reset_en: sata-pm-reset-en {
+			rockchip,pins = <4 RK_PA7 RK_FUNC_GPIO &pcfg_pull_down>;
+		};
+
+		sata_hdd_power_en: sata-hdd-power-en {
+			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_down>;
+		};
+	};
+};
+
+&pwm0 {
+	status = "okay";
+};
+
+&soc_thermal {
+	trips {
+		trip0: trip-point@0 {
+			temperature = <45000>;
+			hysteresis = <5000>;
+			type = "active";
+		};
+		trip1: trip-point@1 {
+			temperature = <50000>;
+			hysteresis = <5000>;
+			type = "active";
+		};
+		trip2: trip-point@2 {
+			temperature = <55000>;
+			hysteresis = <5000>;
+			type = "active";
+		};
+		trip3: trip-point@3 {
+			temperature = <60000>;
+			hysteresis = <5000>;
+			type = "active";
+		};
+		trip4: trip-point@4 {
+			temperature = <65000>;
+			hysteresis = <5000>;
+			type = "active";
+		};
+		trip5: trip-point@5 {
+			temperature = <70000>;
+			hysteresis = <5000>;
+			type = "active";
+		};
+		trip6: trip-point@6 {
+			temperature = <75000>;
+			hysteresis = <5000>;
+			type = "active";
+		};
+		trip7: trip-point@7 {
+			temperature = <80000>;
+			hysteresis = <1000>;
+			type = "active";
+		};
+	};
+	cooling-maps {
+		map0 {
+			trip = <&trip0>;
+			cooling-device = <&fan0 0 1>;
+			contribution = <1024>;
+		};
+		map1 {
+			trip = <&trip1>;
+			cooling-device = <&fan0 1 2>;
+			contribution = <1024>;
+		};
+		map2 {
+			trip = <&trip2>;
+			cooling-device = <&fan0 2 3>;
+			contribution = <1024>;
+		};
+		map3 {
+			trip = <&trip3>;
+			cooling-device = <&fan0 3 4>;
+			contribution = <1024>;
+		};
+		map4 {
+			trip = <&trip4>;
+			cooling-device = <&fan0 4 5>;
+			contribution = <1024>;
+		};
+		map5 {
+			trip = <&trip5>;
+			cooling-device = <&fan0 5 6>;
+			contribution = <1024>;
+		};
+		map6 {
+			trip = <&trip6>;
+			cooling-device = <&fan0 6 7>;
+			contribution = <1024>;
+		};
+		map7 {
+			trip = <&trip7>;
+			cooling-device = <&fan0 7 8>;
+			contribution = <1024>;
+		};
+	};
+};
+
+&vcc3v3_pcie {
+	gpio = <&gpio0 RK_PC4 GPIO_ACTIVE_HIGH>;
+};


### PR DESCRIPTION
Hinlink HNAS is a NAS board basicly based on hinlink h66k adding 4 sata interfaces. The new device tree is based on hinlink h66k, sata power gpio, sata leds and pwm fan with product is added.
Here is the hardware description document in Chinese:
[恒领科技HNAS 2023年款 硬件快速开发指南_20231011.pdf](https://github.com/armbian/linux-rockchip/files/13463227/HNAS.2023._20231011.pdf)
