### PR TITLE
arm64: dts: turing-rk1: fix rtc-hym8563 init failure

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
@@ -313,6 +313,7 @@
 		compatible = "haoyu,hym8563";
 		reg = <0x51>;
 		#clock-cells = <0>;
+		clock-frequency = <32768>;
 		clock-output-names = "hym8563";
 		pinctrl-names = "default";
 		pinctrl-0 = <&hym8563_int>;


### PR DESCRIPTION
Here is a patch to fix an rtc init failure on the rk1. Sorry, I meant to squash this into my previous pr. 

Thanks!