### PR TITLE
arm64: dts: turing-rk1: Fix reading EDID information

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
@@ -594,6 +594,7 @@
 
 &hdmi0 {
 	status = "okay";
+	ddc-i2c-rxfilter = <0x10>;
 };
 
 &hdmi0_in_vp0 {

--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
+++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
@@ -963,8 +963,14 @@ static int hdmi_bus_fmt_color_depth(unsigned int bus_format)
 
 static void dw_hdmi_i2c_init(struct dw_hdmi_qp *hdmi)
 {
+	u32 ddc_i2c_rxfilter;
+
 	/* Software reset */
 	hdmi_writel(hdmi, 0x01, I2CM_CONTROL0);
+
+	/* Configure I2CM hold time and rxfilter */
+	if (device_property_read_u32(hdmi->dev, "ddc-i2c-rxfilter", &ddc_i2c_rxfilter))
+		hdmi_writel(hdmi, ddc_i2c_rxfilter, I2CM_CONFIG0);
 
 	hdmi_modb(hdmi, 0, I2CM_FM_EN, I2CM_INTERFACE_CONTROL0);
 


### PR DESCRIPTION
Hello! This PR will fix reading EDID information on the Turing RK1.

There has been a problem reading data from I2C on this device, and I finally found that adjusting the hold time and rxfilter will fix the problem and allow for successful I2C transfers. The implemented fix will not impact any boards unless they add the device tree property `ddc-i2c-rxfilter`.

Thanks!