### PR TITLE
arm64: dts: rockchip: Add Radxa Zero 3 overlays

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
@@ -47,6 +47,11 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	radxa-nx5-io-rpi-camera-v2-cam1.dtbo \
 	turing-rk1-sata2.dtbo \
 	mixtile-blade3-sata2.dtbo \
+	radxa-zero3-rpi-camera-v2.dtbo \
+	radxa-zero3-rpi-camera-v1.3.dtbo \
+	radxa-zero3-external-antenna.dtbo \
+	radxa-zero3-disabled-ethernet.dtbo \
+	radxa-zero3-disabled-wireless.dtbo \
 	yy3568-camera.dtbo \
 	yy3568-display-dsi0.dtbo \
 	yy3568-display-dsi1.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlay/radxa-zero3-disabled-ethernet.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/radxa-zero3-disabled-ethernet.dts
@@ -1,0 +1,31 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
+
+/ {
+	metadata {
+		title = "Disabled Zero 3W Ethernet";
+		compatible = "radxa,zero3";
+		category = "misc";
+		description = "Disabled Zero 3W Ethernet.";
+	};
+
+	fragment@0 {
+		target = <&mdio1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&gmac1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/overlay/radxa-zero3-disabled-wireless.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/radxa-zero3-disabled-wireless.dts
@@ -1,0 +1,31 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
+
+/ {
+	metadata {
+		title = "Disabled Zero 3E Wireless";
+		compatible = "radxa,zero3";
+		category = "misc";
+		description = "Disabled Zero 3E Wireless.";
+	};
+
+	fragment@0 {
+		target = <&uart1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&sdmmc1>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/overlay/radxa-zero3-external-antenna.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/radxa-zero3-external-antenna.dts
@@ -1,0 +1,46 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
+
+/ {
+	metadata {
+		title = "Enable external antenna";
+		compatible = "radxa,zero3";
+		category = "misc";
+		exclusive = "GPIO3_D2";
+		description = "Enable external antenna.";
+	};
+
+	fragment@0 {
+		target-path = "/";
+
+		__overlay__ {
+			board_antenna: board-antenna {
+				status = "okay";
+				compatible = "regulator-fixed";
+				enable-active-low;
+				gpio = <&gpio3 RK_PD2 GPIO_ACTIVE_LOW>;
+				regulator-always-on;
+				regulator-boot-on;
+				pinctrl-0 = <&ant_1>;
+				pinctrl-names = "default";
+				regulator-name = "board_antenna";
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&pinctrl>;
+
+		__overlay__ {
+			antenna {
+				ant_1: ant-1 {
+					rockchip,pins = <3 RK_PD2 RK_FUNC_GPIO &pcfg_pull_down>;
+				};
+			};
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/overlay/radxa-zero3-rpi-camera-v1.3.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/radxa-zero3-rpi-camera-v1.3.dts
@@ -1,0 +1,156 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
+
+/ {
+	metadata {
+		title = "Enable Raspberry Pi Camera v1.3";
+		compatible = "radxa,zero3";
+		category = "camera";
+		exclusive = "csi2_dphy0";
+		description = "Enable Raspberry Pi Camera v1.3.";
+	};
+
+	fragment@0 {
+		target-path = "/";
+
+		__overlay__ {
+			clk_cam_25m: external-camera-clock-25m {
+				status = "okay";
+				compatible = "fixed-clock";
+				clock-frequency = <25000000>;
+				clock-output-names = "clk_cam_25m";
+				#clock-cells = <0>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c2>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c2m1_xfer>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			camera_ov5647: camera-ov5647@36 {
+				status = "okay";
+				compatible = "ovti,ov5647";
+				reg = <0x36>;
+				clocks = <&clk_cam_25m>;
+				clock-names = "xvclk";
+				pwdn-gpios = <&gpio3 RK_PC6 GPIO_ACTIVE_LOW>;
+				rockchip,camera-module-index = <0>;
+				rockchip,camera-module-facing = "back";
+				rockchip,camera-module-name = "rpi-camera-v1p3";
+				rockchip,camera-module-lens-name = "default";
+
+				port {
+					ucam_out0: endpoint {
+						remote-endpoint = <&mipi_in_ucam0>;
+						data-lanes = <1 2>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&csi2_dphy_hw>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&csi2_dphy0>;
+
+		__overlay__ {
+			status = "okay";
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					mipi_in_ucam0: endpoint@1 {
+						reg = <1>;
+						remote-endpoint = <&ucam_out0>;
+						data-lanes = <1 2>;
+					};
+				};
+
+				port@1 {
+					reg = <1>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					dphy0_out: endpoint@1 {
+						reg = <1>;
+						remote-endpoint = <&isp0_in>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&rkisp_vir0>;
+
+		__overlay__ {
+			status = "okay";
+
+			port {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				isp0_in: endpoint@0 {
+					reg = <0>;
+					remote-endpoint = <&dphy0_out>;
+				};
+			};
+		};
+	};
+
+	fragment@5 {
+		target = <&rkisp>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@6 {
+		target = <&rkisp_mmu>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@7 {
+		target = <&rkcif_mmu>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@8 {
+		target = <&rkcif>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/overlay/radxa-zero3-rpi-camera-v2.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/radxa-zero3-rpi-camera-v2.dts
@@ -1,0 +1,165 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
+
+/ {
+	metadata {
+		title = "Enable Raspberry Pi Camera v2";
+		compatible = "radxa,zero3";
+		category = "camera";
+		exclusive = "csi2_dphy0";
+		description = "Enable Raspberry Pi Camera v2.";
+	};
+
+	fragment@0 {
+		target-path = "/";
+
+		__overlay__ {
+			clk_cam_24m: external-camera-clock-24m {
+				status = "okay";
+				compatible = "fixed-clock";
+				clock-frequency = <24000000>;
+				clock-output-names = "clk_cam_24m";
+				#clock-cells = <0>;
+			};
+
+			camera_pwdn_gpio: camera-pwdn-gpio {
+				status = "okay";
+				compatible = "regulator-fixed";
+				regulator-name = "camera_pwdn_gpio";
+				regulator-always-on;
+				regulator-boot-on;
+				enable-active-high;
+				gpio = <&gpio3 RK_PC6 GPIO_ACTIVE_HIGH>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&i2c2>;
+
+		__overlay__ {
+			status = "okay";
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2c2m1_xfer>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			camera_imx219: camera-imx219@10 {
+				status = "okay";
+				compatible = "sony,imx219";
+				reg = <0x10>;
+				clocks = <&clk_cam_24m>;
+				clock-names = "xvclk";
+				rockchip,camera-module-index = <0>;
+				rockchip,camera-module-facing = "back";
+				rockchip,camera-module-name = "rpi-camera-v2";
+				rockchip,camera-module-lens-name = "default";
+
+				port {
+					ucam_out0: endpoint {
+						remote-endpoint = <&mipi_in_ucam0>;
+						data-lanes = <1 2>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&csi2_dphy_hw>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&csi2_dphy0>;
+
+		__overlay__ {
+			status = "okay";
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					mipi_in_ucam0: endpoint@1 {
+						reg = <1>;
+						remote-endpoint = <&ucam_out0>;
+						data-lanes = <1 2>;
+					};
+				};
+
+				port@1 {
+					reg = <1>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					dphy0_out: endpoint@1 {
+						reg = <1>;
+						remote-endpoint = <&isp0_in>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&rkisp_vir0>;
+
+		__overlay__ {
+			status = "okay";
+
+			port {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				isp0_in: endpoint@0 {
+					reg = <0>;
+					remote-endpoint = <&dphy0_out>;
+				};
+			};
+		};
+	};
+
+	fragment@5 {
+		target = <&rkisp>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@6 {
+		target = <&rkisp_mmu>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@7 {
+		target = <&rkcif_mmu>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@8 {
+		target = <&rkcif>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_main.c
+++ b/drivers/net/wireless/aic8800_sdio/aic8800_fdrv/rwnx_main.c
@@ -502,7 +502,7 @@ static const int rwnx_hwq2uapsd[NL80211_NUM_ACS] = {
 
 
 extern uint8_t scanning;
-int aicwf_dbg_level = LOGERROR|LOGINFO|LOGDEBUG|LOGTRACE;
+int aicwf_dbg_level = LOGERROR;
 module_param(aicwf_dbg_level, int, 0660);
 int testmode = 0;
 char aic_fw_path[200];


### PR DESCRIPTION
Hello! 

This PR adds device tree overlays for the Radxa Zero 3, pulled directly from Radxa's [repo](https://github.com/radxa/overlays). Also, debugging information was left on for the AIC8800 driver, so an additional commit exists to disable it and cleanup dmesg output.

[AR-2158]

[AR-2158]: https://armbian.atlassian.net/browse/AR-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ