### PR TITLE
arm64: dts: rock-5a: pull down data-strobe to fix emmc compatibility

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
@@ -892,6 +892,12 @@
 			rockchip,pins = <0 RK_PC4 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
+
+	emmc {
+		emmc_data_strobe: emmc-data-strobe {
+			rockchip,pins = <2 RK_PA2 1 &pcfg_pull_down>;
+		};
+	};
 };
 
 &gpio0 {


### PR DESCRIPTION
[Mainline has enabled this](https://patchwork.kernel.org/project/linux-rockchip/patch/20231205202900.4617-2-CFSworks@gmail.com/) globally for all 3588 boards. I'm not sure if this is a good idea for the BSP kernel as well.
So only enable it on Rock-5a which is known to be affected.