### PR TITLE
driver: rknpu: Fixing deadlock issue with spin_lock in interrupt hand…

### DIFF
--- a/drivers/rknpu/include/rknpu_drv.h
+++ b/drivers/rknpu/include/rknpu_drv.h
@@ -30,7 +30,7 @@
 
 #define DRIVER_NAME "rknpu"
 #define DRIVER_DESC "RKNPU driver"
-#define DRIVER_DATE "20230825"
+#define DRIVER_DATE "20231018"
 #define DRIVER_MAJOR 0
 #define DRIVER_MINOR 9
 #define DRIVER_PATCHLEVEL 2


### PR DESCRIPTION
There is a npu deadlock bug in rkr6 kernel, fixed in rkr7.1. 6.1-rkr1 is not affected.