### PR TITLE
arm64: dts: Add board bananapim7 for 6.1 kernel

### DIFF
--- a/arch/arm64/boot/dts/rockchip/Makefile
+++ b/arch/arm64/boot/dts/rockchip/Makefile
@@ -205,6 +205,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-toybrick-sd0-android.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-toybrick-sd0-linux.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-toybrick-x0-android.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-toybrick-x0-linux.dtb
+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-bananapi-m7.dts
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-blade3-v101-linux.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-blueberry-edge-v10-linux.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-blueberry-edge-v12-linux.dtb

--- a/arch/arm64/boot/dts/rockchip/rk3588-bananapi-m7.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-bananapi-m7.dts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+
+/dts-v1/;
+
+#include "rk3588-armsom-sige7.dts"
+
+/ {
+	model = "Banana Pi M7";
+	compatible = "bananapi,m7", "rockchip,rk3588";
+};


### PR DESCRIPTION
bananapim7 and armsom-sige7 are the same board