### PR TITLE
Avoid EPROBE_DEFER loop with Rockchip DSI driver

### DIFF
--- a/drivers/gpu/drm/rockchip/dw-mipi-dsi2-rockchip.c
+++ b/drivers/gpu/drm/rockchip/dw-mipi-dsi2-rockchip.c
@@ -1542,7 +1542,7 @@ static int dw_mipi_dsi2_host_attach(struct mipi_dsi_host *host,
 	dsi2->format = device->format;
 	dsi2->mode_flags = device->mode_flags;
 
-	return 0;
+	return component_add(host->dev, &dw_mipi_dsi2_ops);
 }
 
 static int dw_mipi_dsi2_host_detach(struct mipi_dsi_host *host,
@@ -1789,7 +1789,7 @@ static int dw_mipi_dsi2_probe(struct platform_device *pdev)
 		return ret;
 	}
 
-	return component_add(&pdev->dev, &dw_mipi_dsi2_ops);
+	return 0;
 }
 
 static int dw_mipi_dsi2_remove(struct platform_device *pdev)


### PR DESCRIPTION
Previously, the Rockchip DSI driver would register itself as MIPI host during probe, then proceed to register all sub-components, then realize the panel isn't available yet, and defer.
This doesn't work with 6.1 though, and results in an endless loop.
The correct way is to let the DSI driver register as host, then wait for the panel driver to be registered and probed, and then let the panel driver trigger registering the DSI driver's sub-components.