### PR TITLE
Upgrade RKNPU driver to 0.9.6

### DIFF
--- a/drivers/rknpu/include/rknpu_drv.h
+++ b/drivers/rknpu/include/rknpu_drv.h
@@ -29,10 +29,10 @@
 
 #define DRIVER_NAME "rknpu"
 #define DRIVER_DESC "RKNPU driver"
-#define DRIVER_DATE "20240226"
+#define DRIVER_DATE "20240322"
 #define DRIVER_MAJOR 0
 #define DRIVER_MINOR 9
-#define DRIVER_PATCHLEVEL 5
+#define DRIVER_PATCHLEVEL 6
 
 #define LOG_TAG "RKNPU"
 
@@ -52,6 +52,8 @@
 #define LOG_DEV_WARN(dev, fmt, args...) dev_warn(dev, LOG_TAG ": " fmt, ##args)
 #define LOG_DEV_DEBUG(dev, fmt, args...) dev_dbg(dev, LOG_TAG ": " fmt, ##args)
 #define LOG_DEV_ERROR(dev, fmt, args...) dev_err(dev, LOG_TAG ": " fmt, ##args)
+
+#define RKNPU_MAX_IOMMU_DOMAIN_NUM 16
 
 struct rknpu_irqs_data {
 	const char *name;
@@ -120,6 +122,7 @@ struct rknpu_device {
 	spinlock_t irq_lock;
 	struct mutex power_lock;
 	struct mutex reset_lock;
+	struct mutex domain_lock;
 	struct rknpu_subcore_data subcore_datas[RKNPU_MAX_CORES];
 	const struct rknpu_config *config;
 	void __iomem *bw_priority_base;
@@ -163,6 +166,10 @@ struct rknpu_device {
 	void __iomem *nbuf_base_io;
 	struct rknpu_mm *sram_mm;
 	unsigned long power_put_delay;
+	struct iommu_group *iommu_group;
+	int iommu_domain_num;
+	int iommu_domain_id;
+	struct iommu_domain *iommu_domains[RKNPU_MAX_IOMMU_DOMAIN_NUM];
 };
 
 struct rknpu_session {

--- a/drivers/rknpu/include/rknpu_gem.h
+++ b/drivers/rknpu/include/rknpu_gem.h
@@ -60,6 +60,7 @@ struct rknpu_gem_object {
 	struct page **pages;
 	struct sg_table *sgt;
 	struct drm_mm_node mm_node;
+	int iommu_domain_id;
 };
 
 enum rknpu_cache_type {
@@ -71,7 +72,8 @@ enum rknpu_cache_type {
 struct rknpu_gem_object *rknpu_gem_object_create(struct drm_device *dev,
 						 unsigned int flags,
 						 unsigned long size,
-						 unsigned long sram_size);
+						 unsigned long sram_size,
+						 int iommu_domain_id);
 
 /* destroy a buffer with gem object */
 void rknpu_gem_object_destroy(struct rknpu_gem_object *rknpu_obj);

--- a/drivers/rknpu/include/rknpu_ioctl.h
+++ b/drivers/rknpu/include/rknpu_ioctl.h
@@ -129,6 +129,8 @@ enum e_rknpu_action {
 	RKNPU_POWER_OFF = 21,
 	RKNPU_GET_TOTAL_SRAM_SIZE = 22,
 	RKNPU_GET_FREE_SRAM_SIZE = 23,
+	RKNPU_GET_IOMMU_DOMAIN_ID = 24,
+	RKNPU_SET_IOMMU_DOMAIN_ID = 25,
 };
 
 /**
@@ -142,6 +144,8 @@ enum e_rknpu_action {
  * @dma_addr: dma address that access by rknpu.
  * @sram_size: user-desired sram memory allocation size.
  *  - this size value would be page-aligned internally.
+ * @iommu_domain_id: iommu domain id
+ * @reserved: just padding to be 64-bit aligned.
  */
 struct rknpu_mem_create {
 	__u32 handle;
@@ -150,6 +154,8 @@ struct rknpu_mem_create {
 	__u64 obj_addr;
 	__u64 dma_addr;
 	__u64 sram_size;
+	__s32 iommu_domain_id;
+	__u32 reserved;
 };
 
 /**
@@ -244,7 +250,8 @@ struct rknpu_subcore_task {
  * @task_counter: task counter
  * @priority: submit priority
  * @task_obj_addr: address of task object
- * @regcfg_obj_addr: address of register config object
+ * @iommu_domain_id: iommu domain id
+ * @reserved: just padding to be 64-bit aligned.
  * @task_base_addr: task base address
  * @hw_elapse_time: hardware elapse time
  * @core_mask: core mask of rknpu
@@ -260,7 +267,8 @@ struct rknpu_submit {
 	__u32 task_counter;
 	__s32 priority;
 	__u64 task_obj_addr;
-	__u64 regcfg_obj_addr;
+	__u32 iommu_domain_id;
+	__u32 reserved;
 	__u64 task_base_addr;
 	__s64 hw_elapse_time;
 	__u32 core_mask;

--- a/drivers/rknpu/include/rknpu_iommu.h
+++ b/drivers/rknpu/include/rknpu_iommu.h
@@ -37,4 +37,12 @@ dma_addr_t rknpu_iommu_dma_alloc_iova(struct iommu_domain *domain, size_t size,
 void rknpu_iommu_dma_free_iova(struct rknpu_iommu_dma_cookie *cookie,
 			       dma_addr_t iova, size_t size);
 
+int rknpu_iommu_init_domain(struct rknpu_device *rknpu_dev);
+int rknpu_iommu_switch_domain(struct rknpu_device *rknpu_dev, int domain_id);
+void rknpu_iommu_free_domains(struct rknpu_device *rknpu_dev);
+
+#if KERNEL_VERSION(5, 10, 0) < LINUX_VERSION_CODE
+int iommu_get_dma_cookie(struct iommu_domain *domain);
+#endif
+
 #endif

--- a/drivers/rknpu/include/rknpu_job.h
+++ b/drivers/rknpu/include/rknpu_job.h
@@ -48,6 +48,7 @@ struct rknpu_job {
 	ktime_t hw_recoder_time;
 	ktime_t hw_elapse_time;
 	atomic_t submit_count[RKNPU_MAX_CORES];
+	int iommu_domain_id;
 };
 
 irqreturn_t rknpu_core0_irq_handler(int irq, void *data);

--- a/drivers/rknpu/include/rknpu_mem.h
+++ b/drivers/rknpu/include/rknpu_mem.h
@@ -37,10 +37,10 @@ struct rknpu_mem_object {
 	unsigned int owner;
 };
 
-int rknpu_mem_create_ioctl(struct rknpu_device *rknpu_dev, unsigned long data,
-			   struct file *file);
-int rknpu_mem_destroy_ioctl(struct rknpu_device *rknpu_dev, unsigned long data,
-			    struct file *file);
+int rknpu_mem_create_ioctl(struct rknpu_device *rknpu_dev, struct file *file,
+			   unsigned int cmd, unsigned long data);
+int rknpu_mem_destroy_ioctl(struct rknpu_device *rknpu_dev, struct file *file,
+			    unsigned long data);
 int rknpu_mem_sync_ioctl(struct rknpu_device *rknpu_dev, unsigned long data);
 
 #endif

--- a/drivers/rknpu/rknpu_devfreq.c
+++ b/drivers/rknpu/rknpu_devfreq.c
@@ -75,6 +75,25 @@ static struct devfreq_governor devfreq_rknpu_ondemand = {
 	.event_handler = devfreq_rknpu_ondemand_handler,
 };
 
+static int rk3576_npu_set_read_margin(struct device *dev,
+				      struct rockchip_opp_info *opp_info,
+				      u32 rm)
+{
+	if (!opp_info->grf || !opp_info->volt_rm_tbl)
+		return 0;
+
+	if (rm == opp_info->current_rm || rm == UINT_MAX)
+		return 0;
+
+	LOG_DEV_DEBUG(dev, "set rm to %d\n", rm);
+
+	regmap_write(opp_info->grf, 0x08, 0x001c0000 | (rm << 2));
+	regmap_write(opp_info->grf, 0x0c, 0x003c0000 | (rm << 2));
+	regmap_write(opp_info->grf, 0x10, 0x001c0000 | (rm << 2));
+
+	return 0;
+}
+
 static int rk3588_npu_get_soc_info(struct device *dev, struct device_node *np,
 				   int *bin, int *process)
 {
@@ -213,6 +232,14 @@ static int npu_opp_config_clks(struct device *dev, struct opp_table *opp_table,
 }
 #endif
 
+static const struct rockchip_opp_data rk3576_npu_opp_data = {
+	.set_read_margin = rk3576_npu_set_read_margin,
+#if KERNEL_VERSION(6, 1, 0) <= LINUX_VERSION_CODE
+	.config_regulators = npu_opp_config_regulators,
+	.config_clks = npu_opp_config_clks,
+#endif
+};
+
 static const struct rockchip_opp_data rk3588_npu_opp_data = {
 	.get_soc_info = rk3588_npu_get_soc_info,
 	.set_soc_info = rk3588_npu_set_soc_info,
@@ -224,6 +251,10 @@ static const struct rockchip_opp_data rk3588_npu_opp_data = {
 };
 
 static const struct of_device_id rockchip_npu_of_match[] = {
+	{
+		.compatible = "rockchip,rk3576",
+		.data = (void *)&rk3576_npu_opp_data,
+	},
 	{
 		.compatible = "rockchip,rk3588",
 		.data = (void *)&rk3588_npu_opp_data,

--- a/drivers/rknpu/rknpu_gem.c
+++ b/drivers/rknpu/rknpu_gem.c
@@ -616,7 +616,8 @@ static void rknpu_gem_free_buf_with_cache(struct rknpu_gem_object *rknpu_obj,
 struct rknpu_gem_object *rknpu_gem_object_create(struct drm_device *drm,
 						 unsigned int flags,
 						 unsigned long size,
-						 unsigned long sram_size)
+						 unsigned long sram_size,
+						 int iommu_domain_id)
 {
 	struct rknpu_device *rknpu_dev = drm->dev_private;
 	struct rknpu_gem_object *rknpu_obj = NULL;
@@ -629,6 +630,13 @@ struct rknpu_gem_object *rknpu_gem_object_create(struct drm_device *drm,
 	}
 
 	remain_ddr_size = round_up(size, PAGE_SIZE);
+
+	rknpu_obj = rknpu_gem_init(drm, remain_ddr_size);
+	if (IS_ERR(rknpu_obj))
+		return rknpu_obj;
+
+	if (!rknpu_iommu_switch_domain(rknpu_dev, iommu_domain_id))
+		rknpu_obj->iommu_domain_id = iommu_domain_id;
 
 	if (!rknpu_dev->iommu_en && (flags & RKNPU_MEM_NON_CONTIGUOUS)) {
 		/*
@@ -647,10 +655,6 @@ struct rknpu_gem_object *rknpu_gem_object_create(struct drm_device *drm,
 
 		if (sram_size != 0)
 			sram_size = round_up(sram_size, PAGE_SIZE);
-
-		rknpu_obj = rknpu_gem_init(drm, remain_ddr_size);
-		if (IS_ERR(rknpu_obj))
-			return rknpu_obj;
 
 		/* set memory type and cache attribute from user side. */
 		rknpu_obj->flags = flags;
@@ -688,15 +692,9 @@ struct rknpu_gem_object *rknpu_gem_object_create(struct drm_device *drm,
 	} else if (IS_ENABLED(CONFIG_NO_GKI) &&
 		   (flags & RKNPU_MEM_TRY_ALLOC_NBUF) &&
 		   rknpu_dev->nbuf_size > 0) {
-		size_t nbuf_size = 0;
-
-		rknpu_obj = rknpu_gem_init(drm, remain_ddr_size);
-		if (IS_ERR(rknpu_obj))
-			return rknpu_obj;
-
-		nbuf_size = remain_ddr_size <= rknpu_dev->nbuf_size ?
-				    remain_ddr_size :
-				    rknpu_dev->nbuf_size;
+		size_t nbuf_size = remain_ddr_size <= rknpu_dev->nbuf_size ?
+					   remain_ddr_size :
+					   rknpu_dev->nbuf_size;
 
 		/* set memory type and cache attribute from user side. */
 		rknpu_obj->flags = flags;
@@ -713,10 +711,6 @@ struct rknpu_gem_object *rknpu_gem_object_create(struct drm_device *drm,
 	}
 
 	if (remain_ddr_size > 0) {
-		rknpu_obj = rknpu_gem_init(drm, remain_ddr_size);
-		if (IS_ERR(rknpu_obj))
-			return rknpu_obj;
-
 		/* set memory type and cache attribute from user side. */
 		rknpu_obj->flags = flags;
 
@@ -725,13 +719,12 @@ struct rknpu_gem_object *rknpu_gem_object_create(struct drm_device *drm,
 			goto gem_release;
 	}
 
-	if (rknpu_obj)
-		LOG_DEBUG(
-			"created dma addr: %pad, cookie: %p, ddr size: %lu, sram size: %lu, nbuf size: %lu, attrs: %#lx, flags: %#x\n",
-			&rknpu_obj->dma_addr, rknpu_obj->cookie,
-			rknpu_obj->size, rknpu_obj->sram_size,
-			rknpu_obj->nbuf_size, rknpu_obj->dma_attrs,
-			rknpu_obj->flags);
+	LOG_DEBUG(
+		"created dma addr: %pad, cookie: %p, ddr size: %lu, sram size: %lu, nbuf size: %lu, attrs: %#lx, flags: %#x, iommu domain id: %d\n",
+		&rknpu_obj->dma_addr, rknpu_obj->cookie, rknpu_obj->size,
+		rknpu_obj->sram_size, rknpu_obj->nbuf_size,
+		rknpu_obj->dma_attrs, rknpu_obj->flags,
+		rknpu_obj->iommu_domain_id);
 
 	return rknpu_obj;
 
@@ -749,11 +742,14 @@ gem_release:
 void rknpu_gem_object_destroy(struct rknpu_gem_object *rknpu_obj)
 {
 	struct drm_gem_object *obj = &rknpu_obj->base;
+	struct rknpu_device *rknpu_dev = obj->dev->dev_private;
 
 	LOG_DEBUG(
 		"destroy dma addr: %pad, cookie: %p, size: %lu, attrs: %#lx, flags: %#x, handle count: %d\n",
 		&rknpu_obj->dma_addr, rknpu_obj->cookie, rknpu_obj->size,
 		rknpu_obj->dma_attrs, rknpu_obj->flags, obj->handle_count);
+
+	rknpu_iommu_switch_domain(rknpu_dev, rknpu_obj->iommu_domain_id);
 
 	/*
 	 * do not release memory region from exporter.
@@ -767,8 +763,6 @@ void rknpu_gem_object_destroy(struct rknpu_gem_object *rknpu_obj)
 	} else {
 		if (IS_ENABLED(CONFIG_ROCKCHIP_RKNPU_SRAM) &&
 		    rknpu_obj->sram_size > 0) {
-			struct rknpu_device *rknpu_dev = obj->dev->dev_private;
-
 			if (rknpu_obj->sram_obj != NULL)
 				rknpu_mm_free(rknpu_dev->sram_mm,
 					      rknpu_obj->sram_obj);
@@ -786,7 +780,7 @@ void rknpu_gem_object_destroy(struct rknpu_gem_object *rknpu_obj)
 	rknpu_gem_release(rknpu_obj);
 }
 
-int rknpu_gem_create_ioctl(struct drm_device *dev, void *data,
+int rknpu_gem_create_ioctl(struct drm_device *drm, void *data,
 			   struct drm_file *file_priv)
 {
 	struct rknpu_mem_create *args = data;
@@ -795,8 +789,9 @@ int rknpu_gem_create_ioctl(struct drm_device *dev, void *data,
 
 	rknpu_obj = rknpu_gem_object_find(file_priv, args->handle);
 	if (!rknpu_obj) {
-		rknpu_obj = rknpu_gem_object_create(
-			dev, args->flags, args->size, args->sram_size);
+		rknpu_obj = rknpu_gem_object_create(drm, args->flags,
+						    args->size, args->sram_size,
+						    args->iommu_domain_id);
 		if (IS_ERR(rknpu_obj))
 			return PTR_ERR(rknpu_obj);
 
@@ -832,15 +827,18 @@ int rknpu_gem_map_ioctl(struct drm_device *dev, void *data,
 #endif
 }
 
-int rknpu_gem_destroy_ioctl(struct drm_device *dev, void *data,
+int rknpu_gem_destroy_ioctl(struct drm_device *drm, void *data,
 			    struct drm_file *file_priv)
 {
+	struct rknpu_device *rknpu_dev = drm->dev_private;
 	struct rknpu_gem_object *rknpu_obj = NULL;
 	struct rknpu_mem_destroy *args = data;
 
 	rknpu_obj = rknpu_gem_object_find(file_priv, args->handle);
 	if (!rknpu_obj)
 		return -EINVAL;
+
+	rknpu_iommu_switch_domain(rknpu_dev, rknpu_obj->iommu_domain_id);
 
 	// rknpu_gem_object_put(&rknpu_obj->base);
 
@@ -1045,7 +1043,7 @@ int rknpu_gem_dumb_create(struct drm_file *file_priv, struct drm_device *drm,
 	else
 		flags = RKNPU_MEM_CONTIGUOUS | RKNPU_MEM_WRITE_COMBINE;
 
-	rknpu_obj = rknpu_gem_object_create(drm, flags, args->size, 0);
+	rknpu_obj = rknpu_gem_object_create(drm, flags, args->size, 0, 0);
 	if (IS_ERR(rknpu_obj)) {
 		LOG_DEV_ERROR(drm->dev, "gem object allocate failed.\n");
 		return PTR_ERR(rknpu_obj);

--- a/drivers/rknpu/rknpu_iommu.c
+++ b/drivers/rknpu/rknpu_iommu.c
@@ -59,3 +59,196 @@ void rknpu_iommu_dma_free_iova(struct rknpu_iommu_dma_cookie *cookie,
 
 	free_iova_fast(iovad, iova_pfn(iovad, iova), size >> iova_shift(iovad));
 }
+
+#if defined(CONFIG_IOMMU_API) && defined(CONFIG_NO_GKI)
+
+#if KERNEL_VERSION(6, 1, 0) <= LINUX_VERSION_CODE
+struct iommu_group {
+	struct kobject kobj;
+	struct kobject *devices_kobj;
+	struct list_head devices;
+#ifdef __ANDROID_COMMON_KERNEL__
+	struct xarray pasid_array;
+#endif
+	struct mutex mutex;
+	void *iommu_data;
+	void (*iommu_data_release)(void *iommu_data);
+	char *name;
+	int id;
+	struct iommu_domain *default_domain;
+	struct iommu_domain *blocking_domain;
+	struct iommu_domain *domain;
+	struct list_head entry;
+	unsigned int owner_cnt;
+	void *owner;
+};
+#else
+struct iommu_group {
+	struct kobject kobj;
+	struct kobject *devices_kobj;
+	struct list_head devices;
+	struct mutex mutex;
+	struct blocking_notifier_head notifier;
+	void *iommu_data;
+	void (*iommu_data_release)(void *iommu_data);
+	char *name;
+	int id;
+	struct iommu_domain *default_domain;
+	struct iommu_domain *domain;
+	struct list_head entry;
+};
+#endif
+
+int rknpu_iommu_init_domain(struct rknpu_device *rknpu_dev)
+{
+	// init domain 0
+	if (!rknpu_dev->iommu_domains[0]) {
+		rknpu_dev->iommu_domain_id = 0;
+		rknpu_dev->iommu_domains[rknpu_dev->iommu_domain_id] =
+			iommu_get_domain_for_dev(rknpu_dev->dev);
+		rknpu_dev->iommu_domain_num = 1;
+	}
+	return 0;
+}
+
+int rknpu_iommu_switch_domain(struct rknpu_device *rknpu_dev, int domain_id)
+{
+	struct iommu_domain *src_domain = NULL;
+	struct iommu_domain *dst_domain = NULL;
+	struct bus_type *bus = NULL;
+	int src_domain_id = 0;
+	int ret = -EINVAL;
+
+	if (!rknpu_dev->iommu_en)
+		return -EINVAL;
+
+	if (domain_id < 0 || domain_id > (RKNPU_MAX_IOMMU_DOMAIN_NUM - 1)) {
+		LOG_DEV_ERROR(
+			rknpu_dev->dev,
+			"invalid iommu domain id: %d, reuse domain id: %d\n",
+			domain_id, rknpu_dev->iommu_domain_id);
+		return -EINVAL;
+	}
+
+	bus = rknpu_dev->dev->bus;
+	if (!bus)
+		return -EFAULT;
+
+	mutex_lock(&rknpu_dev->domain_lock);
+
+	src_domain_id = rknpu_dev->iommu_domain_id;
+	if (domain_id == src_domain_id) {
+		mutex_unlock(&rknpu_dev->domain_lock);
+		return 0;
+	}
+
+	src_domain = iommu_get_domain_for_dev(rknpu_dev->dev);
+	if (src_domain != rknpu_dev->iommu_domains[src_domain_id]) {
+		LOG_DEV_ERROR(
+			rknpu_dev->dev,
+			"mismatch domain get from iommu_get_domain_for_dev\n");
+		mutex_unlock(&rknpu_dev->domain_lock);
+		return -EINVAL;
+	}
+
+	dst_domain = rknpu_dev->iommu_domains[domain_id];
+	if (dst_domain != NULL) {
+		iommu_detach_device(src_domain, rknpu_dev->dev);
+		ret = iommu_attach_device(dst_domain, rknpu_dev->dev);
+		if (ret) {
+			LOG_DEV_ERROR(
+				rknpu_dev->dev,
+				"failed to attach dst iommu domain, id: %d, ret: %d\n",
+				domain_id, ret);
+			if (iommu_attach_device(src_domain, rknpu_dev->dev)) {
+				LOG_DEV_ERROR(
+					rknpu_dev->dev,
+					"failed to reattach src iommu domain, id: %d\n",
+					src_domain_id);
+			}
+			mutex_unlock(&rknpu_dev->domain_lock);
+			return ret;
+		}
+		rknpu_dev->iommu_domain_id = domain_id;
+	} else {
+		uint64_t dma_limit = 1ULL << 32;
+
+		dst_domain = iommu_domain_alloc(bus);
+		if (!dst_domain) {
+			LOG_DEV_ERROR(rknpu_dev->dev,
+				      "failed to allocate iommu domain\n");
+			mutex_unlock(&rknpu_dev->domain_lock);
+			return -EIO;
+		}
+		// init domain iova_cookie
+		iommu_get_dma_cookie(dst_domain);
+
+		iommu_detach_device(src_domain, rknpu_dev->dev);
+		ret = iommu_attach_device(dst_domain, rknpu_dev->dev);
+		if (ret) {
+			LOG_DEV_ERROR(
+				rknpu_dev->dev,
+				"failed to attach iommu domain, id: %d, ret: %d\n",
+				domain_id, ret);
+			iommu_domain_free(dst_domain);
+			mutex_unlock(&rknpu_dev->domain_lock);
+			return ret;
+		}
+
+		// set domain type to dma domain
+		dst_domain->type |= __IOMMU_DOMAIN_DMA_API;
+		// iommu dma init domain
+		iommu_setup_dma_ops(rknpu_dev->dev, 0, dma_limit);
+
+		rknpu_dev->iommu_domain_id = domain_id;
+		rknpu_dev->iommu_domains[domain_id] = dst_domain;
+		rknpu_dev->iommu_domain_num++;
+	}
+
+	// reset default iommu domain
+	rknpu_dev->iommu_group->default_domain = dst_domain;
+
+	mutex_unlock(&rknpu_dev->domain_lock);
+
+	LOG_INFO("switch iommu domain from %d to %d\n", src_domain_id,
+		 domain_id);
+
+	return ret;
+}
+
+void rknpu_iommu_free_domains(struct rknpu_device *rknpu_dev)
+{
+	int i = 0;
+
+	rknpu_iommu_switch_domain(rknpu_dev, 0);
+
+	for (i = 1; i < RKNPU_MAX_IOMMU_DOMAIN_NUM; i++) {
+		struct iommu_domain *domain = rknpu_dev->iommu_domains[i];
+
+		if (domain == NULL)
+			continue;
+
+		iommu_detach_device(domain, rknpu_dev->dev);
+		iommu_domain_free(domain);
+
+		rknpu_dev->iommu_domains[i] = NULL;
+	}
+}
+
+#else
+
+int rknpu_iommu_init_domain(struct rknpu_device *rknpu_dev)
+{
+	return 0;
+}
+
+int rknpu_iommu_switch_domain(struct rknpu_device *rknpu_dev, int domain_id)
+{
+	return 0;
+}
+
+void rknpu_iommu_free_domains(struct rknpu_device *rknpu_dev)
+{
+}
+
+#endif

--- a/drivers/rknpu/rknpu_mem.c
+++ b/drivers/rknpu/rknpu_mem.c
@@ -17,8 +17,8 @@
 
 #ifdef CONFIG_ROCKCHIP_RKNPU_DMA_HEAP
 
-int rknpu_mem_create_ioctl(struct rknpu_device *rknpu_dev, unsigned long data,
-			   struct file *file)
+int rknpu_mem_create_ioctl(struct rknpu_device *rknpu_dev, struct file *file,
+			   unsigned int cmd, unsigned long data)
 {
 	struct rknpu_mem_create args;
 	int ret = -EINVAL;
@@ -33,13 +33,19 @@ int rknpu_mem_create_ioctl(struct rknpu_device *rknpu_dev, unsigned long data,
 	struct rknpu_session *session = NULL;
 	int i, fd;
 	unsigned int length, page_count;
+	unsigned int in_size = _IOC_SIZE(cmd);
+	unsigned int k_size = sizeof(struct rknpu_mem_create);
+	char *k_data = (char *)&args;
 
 	if (unlikely(copy_from_user(&args, (struct rknpu_mem_create *)data,
-				    sizeof(struct rknpu_mem_create)))) {
+				    in_size))) {
 		LOG_ERROR("%s: copy_from_user failed\n", __func__);
 		ret = -EFAULT;
 		return ret;
 	}
+
+	if (k_size > in_size)
+		memset(k_data + in_size, 0, k_size - in_size);
 
 	if (args.flags & RKNPU_MEM_NON_CONTIGUOUS) {
 		LOG_ERROR("%s: malloc iommu memory unsupported in current!\n",
@@ -147,7 +153,7 @@ int rknpu_mem_create_ioctl(struct rknpu_device *rknpu_dev, unsigned long data,
 		(__u64)rknpu_obj->dma_addr);
 
 	if (unlikely(copy_to_user((struct rknpu_mem_create *)data, &args,
-				  sizeof(struct rknpu_mem_create)))) {
+				  in_size))) {
 		LOG_ERROR("%s: copy_to_user failed\n", __func__);
 		ret = -EFAULT;
 		goto err_unmap_kv_addr;
@@ -194,8 +200,8 @@ err_free_obj:
 	return ret;
 }
 
-int rknpu_mem_destroy_ioctl(struct rknpu_device *rknpu_dev, unsigned long data,
-			    struct file *file)
+int rknpu_mem_destroy_ioctl(struct rknpu_device *rknpu_dev, struct file *file,
+			    unsigned long data)
 {
 	struct rknpu_mem_object *rknpu_obj, *entry, *q;
 	struct rknpu_session *session = NULL;


### PR DESCRIPTION
I was able to fix the issue https://github.com/armbian/linux-rockchip/issues/167 on my own. Tried to compile it, seems to work.

This driver version allows to run LLMs on RK3588 and similar chips. Check this out:
- https://github.com/airockchip/rknn-llm/tree/main
- https://www.reddit.com/r/RockchipNPU/comments/1c8176q/some_thoughts_on_the_rkllm_sdk/