### PR TITLE
Orange Pi 5 Plus load average >= 1 

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
@@ -151,7 +151,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rk3588-uart8-m0-full.dtbo \
 	rk3588-uart8-m1.dtbo \
 	rk3588-w1-gpio3-b3.dtbo \
-	rk3588-w1-gpio4-b1.dtbo
+	rk3588-w1-gpio4-b1.dtbo \
+	rk3588-hdmirx.dtbo
 
 
 dtbotxt-$(CONFIG_ARCH_ROCKCHIP) += \

--- a/arch/arm64/boot/dts/rockchip/overlay/rk3588-hdmirx.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/rk3588-hdmirx.dts
@@ -1,0 +1,12 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&hdmirx_ctrler>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
@@ -320,8 +320,3 @@
 	assigned-clock-rates = <200000000>;
 	num-cs = <2>;
 };
-/*** 40 pins ***/
-
-&hdmirx_ctrler {
-	status = "okay";
-};


### PR DESCRIPTION
On the Orange Pi 5 Plus, hdmirx spams system interrupts causing a load average greater than 1.00, this happens on both the 5.10 and 6.1 kernels. I have a workaround here disabling hdmirx in the device tree and adding an overlay to enable hdmirx. A proper fix in the hdmirx driver will be required in the future. 

The load average issue has been discussed for a few months here: https://github.com/Joshua-Riek/ubuntu-rockchip/issues/606

[AR-2143]

[AR-2143]: https://armbian.atlassian.net/browse/AR-2143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ