### PR TITLE
Add dynamic-power-coefficient properties to all cores

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s.dtsi
@@ -452,6 +452,7 @@
 			d-cache-line-size = <64>;
 			d-cache-sets = <128>;
 			next-level-cache = <&l2_cache_l1>;
+			dynamic-power-coefficient = <100>;
 		};
 
 		cpu_l2: cpu@200 {
@@ -470,6 +471,7 @@
 			d-cache-line-size = <64>;
 			d-cache-sets = <128>;
 			next-level-cache = <&l2_cache_l2>;
+			dynamic-power-coefficient = <100>;
 		};
 
 		cpu_l3: cpu@300 {
@@ -488,6 +490,7 @@
 			d-cache-line-size = <64>;
 			d-cache-sets = <128>;
 			next-level-cache = <&l2_cache_l3>;
+			dynamic-power-coefficient = <100>;
 		};
 
 		cpu_b0: cpu@400 {
@@ -526,6 +529,7 @@
 			d-cache-line-size = <64>;
 			d-cache-sets = <256>;
 			next-level-cache = <&l2_cache_b1>;
+			dynamic-power-coefficient = <300>;
 		};
 
 		cpu_b2: cpu@600 {
@@ -564,6 +568,7 @@
 			d-cache-line-size = <64>;
 			d-cache-sets = <256>;
 			next-level-cache = <&l2_cache_b3>;
+			dynamic-power-coefficient = <300>;
 		};
 
 		idle-states {


### PR DESCRIPTION
Correct dynamic-power-coefficient properties for the cores are a prerequisit for schedutil/EAS to work correctly.

RK's 100/300 values are BS of course, just compare with RK3399: https://patchwork.kernel.org/project/linux-arm-kernel/patch/1500974575-2244-1-git-send-email-wxt@rock-chips.com/#20763985