### PR TITLE
arm64: dts: rockchip: Enable the missing av1d nodes

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-armsom-sige7.dts
@@ -221,6 +221,10 @@
 	};
 };
 
+&av1d {
+	status = "okay";
+};
+
 &av1d_mmu {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588-armsom-w3.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-armsom-w3.dts
@@ -306,6 +306,14 @@
 	};
 };
 
+&av1d {
+	status = "okay";
+};
+
+&av1d_mmu {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-blade3-v101-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blade3-v101-linux.dts
@@ -230,6 +230,10 @@
 	status = "disabled";
 };*/
 
+&av1d {
+	status = "okay";
+};
+
 &av1d_mmu {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588-blueberry.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blueberry.dtsi
@@ -80,6 +80,10 @@
 	};
 };
 
+&av1d {
+	status = "okay";
+};
+
 &av1d_mmu {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
@@ -369,6 +369,10 @@
 		regulator-always-on;
 	};
 };
+
+&av1d {
+	status = "okay";
+};
  
 &av1d_mmu {
 	status = "okay";

--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
@@ -300,6 +300,10 @@
 	};
 };
 
+&av1d {
+	status = "okay";
+};
+
 &av1d_mmu {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5-pro.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5-pro.dts
@@ -286,6 +286,10 @@
 	};
 };
 
+&av1d {
+	status = "okay";
+};
+
 &av1d_mmu {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-cm5.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-cm5.dtsi
@@ -110,6 +110,14 @@
 	};
 };
 
+&av1d {
+	status = "okay";
+};
+
+&av1d_mmu {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;

--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-module.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-module.dtsi
@@ -133,6 +133,14 @@
 	};
 };
 
+&av1d {
+	status = "okay";
+};
+
+&av1d_mmu {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;

--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
@@ -169,6 +169,10 @@
 	};
 };
 
+&av1d {
+	status = "okay";
+};
+
 &av1d_mmu {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
@@ -221,6 +221,14 @@
 	};
 };
 
+&av1d {
+	status = "okay";
+};
+
+&av1d_mmu {
+	status = "okay";
+};
+
 /* CPU */
 
 &cpu_l0 {


### PR DESCRIPTION
Required by the RKMPP AV1 hardware decoding in
Chromium (libv4l-rkmpp), FFmpeg and Gstreamer.

The `av1d` and `av1_mmu` nodes are disabled by default as per https://github.com/armbian/linux-rockchip/blob/a93767dc2e9b0f29c33c080f77e8241208b9518a/arch/arm64/boot/dts/rockchip/rk3588s.dtsi#L4353-L4385

Tested with a few clips and it also works on Rock-5C.
```
root@rock-5c:~# dmesg | grep av1d
[   12.953757] rk_iommu fdca0000.iommu: av1d iommu enabled
[   13.567192] mpp_av1dec fdc70000.av1d: Adding to iommu group 14
[   13.567556] mpp_av1dec fdc70000.av1d: probing start
[   13.568110] mpp_av1dec fdc70000.av1d: probing finish
```

```
root@rock-5c:~# ./ffmpeg -hide_banner -hwaccel rkmpp -hwaccel_output_format drm_prime -afbc on -i ~/bbb_sunflower_1080p_30fps_normal_5min.mp4 -an -sn -f null -
...
Stream mapping:
  Stream #0:0 -> #0:0 (av1 (av1_rkmpp) -> wrapped_avframe (native))
Press [q] to stop, [?] for help
Output #0, null, to 'pipe:':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomav01dby1iso2mp41
    title           : Big Buck Bunny, Sunflower version
    artist          : Blender Foundation 2008, Janus Bager Kristensen 2013
    composer        : Sacha Goedegebure
    genre           : Animation
    comment         : Creative Commons Attribution 3.0 - http://bbb3d.renderfarming.net
    encoder         : Lavf60.16.100
  Stream #0:0(und): Video: wrapped_avframe, drm_prime(tv, progressive), 1920x1080 [SAR 1:1 DAR 16:9], q=2-31, 200 kb/s, 30 fps, 30 tbn (default)
    Metadata:
      handler_name    : GPAC ISO Video Handler
      vendor_id       : [0][0][0][0]
      encoder         : Lavc60.31.102 wrapped_avframe
[out#0/null @ 0xaaaad0006650] video:4219kB audio:0kB subtitle:0kB other streams:0kB global headers:0kB muxing overhead: unknown
frame= 9000 fps=242 q=-0.0 Lsize=N/A time=00:04:59.96 bitrate=N/A speed=8.08x
```