### PR TITLE
arm64: dts: rockchip: opi5-plus: remove wrong USB nodes

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
@@ -1280,14 +1280,6 @@
     status = "okay";
 };
 
-&usbhost3_0 {
-    status = "okay";
-};
-
-&usbhost_dwc3_0 {
-    status = "okay";
-};
-
 &usbdrd3_1 {
     status = "okay";
 };


### PR DESCRIPTION
I've mistakently added these nodes as enabled in https://github.com/armbian/linux-rockchip/pull/183. Let's remove them