### PR TITLE
6.1-rkr1: sync FriendlyElec's DTs from vendor (common, R6S, R6C, T6, CM3588) + add T6-LTS DT

### DIFF
--- a/arch/arm64/boot/dts/rockchip/Makefile
+++ b/arch/arm64/boot/dts/rockchip/Makefile
@@ -291,6 +291,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-armsom-w3.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-armsom-sige7.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-nanopc-cm3588-nas.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-nanopc-t6.dtb
+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-nanopc-t6-lts.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-nvr-demo-v10.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-nvr-demo-v10-android.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-nvr-demo-v10-ipc-4x-linux.dtb

--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-cm3588-nas.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-cm3588-nas.dts
@@ -79,8 +79,10 @@
 		status = "disabled";
 		compatible = "pwm-fan";
 		#cooling-cells = <2>;
+		fan-supply = <&vcc5v0_sys>;
 		pwms = <&pwm1 0 50000 0>;
-		cooling-levels = <0 50 100 150 200 255>;
+		cooling-levels = <0 35 64 100 150 255>;
+		rockchip,hold-time-ms = <2000>;
 		rockchip,temp-trips = <
 			50000	1
 			55000	2
@@ -293,6 +295,7 @@
 	status = "okay";
 
 	#sound-dai-cells = <1>;
+	edid-version = <3>;
 	/* Effective level used to trigger HPD: 0-low, 1-high */
 	hpd-trigger-level = <1>;
 	hdmirx-det-gpios = <&gpio1 RK_PD5 GPIO_ACTIVE_LOW>;
@@ -419,6 +422,7 @@
 };
 
 &i2c8 {
+	status = "okay";
 	pinctrl-0 = <&i2c8m2_xfer>;
 	/* connected with Header_2.54MM */
 };
@@ -429,6 +433,7 @@
 		     &i2s0_sclk
 		     &i2s0_sdi0
 		     &i2s0_sdo0>;
+	rockchip,trcm-sync-tx-only;
 };
 
 &i2s6_8ch {

--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6-lts.dts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2023 FriendlyElec Computer Tech. Co., Ltd.
+ * (http://www.friendlyelec.com)
+ */
+
+/dts-v1/;
+#include "rk3588-nanopc-t6.dts"
+
+/ {
+	model = "FriendlyElec NanoPC-T6 LTS";
+	compatible = "friendlyelec,nanopc-t6", "rockchip,rk3588";
+
+	vcc5v0_host_20: vcc5v0-host-20 {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio1 RK_PA4 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&vcc5v0_host20_en>;
+		regulator-name = "vcc5v0_host_20";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		vin-supply = <&vcc5v0_usb>;
+	};
+};
+
+&u2phy3_host {
+	phy-supply = <&vcc5v0_host_20>;
+};

--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
@@ -77,8 +77,10 @@
 		status = "okay";
 		compatible = "pwm-fan";
 		#cooling-cells = <2>;
+		fan-supply = <&vcc5v0_sys>;
 		pwms = <&pwm1 0 50000 0>;
-		cooling-levels = <0 50 100 150 200 255>;
+		cooling-levels = <0 35 64 100 150 255>;
+		rockchip,hold-time-ms = <2000>;
 		rockchip,temp-trips = <
 			50000	1
 			55000	2
@@ -208,9 +210,9 @@
 };
 
 &hdmi0 {
+	cec-enable = "true";
 	enable-gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
 	status = "okay";
-	cec-enable = "true";
 };
 
 &hdmi0_in_vp0 {
@@ -230,9 +232,9 @@
 };
 
 &hdmi1 {
+	cec-enable = "true";
 	enable-gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_HIGH>;
 	status = "okay";
-	cec-enable = "true";
 };
 
 &hdmi1_in_vp0 {
@@ -260,6 +262,7 @@
 	status = "okay";
 
 	#sound-dai-cells = <1>;
+	edid-version = <3>;
 	/* Effective level used to trigger HPD: 0-low, 1-high */
 	hpd-trigger-level = <1>;
 	hdmirx-det-gpios = <&gpio1 RK_PD5 GPIO_ACTIVE_LOW>;
@@ -406,6 +409,7 @@
 		     &i2s0_sclk
 		     &i2s0_sdi0
 		     &i2s0_sdo0>;
+	rockchip,trcm-sync-tx-only;
 };
 
 &i2s6_8ch {
@@ -571,6 +575,11 @@
 	usb {
 		vcc5v0_host30_en: vcc5v0-host30-en {
 			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		/omit-if-no-ref/
+		vcc5v0_host20_en: vcc5v0-host20-en {
+			rockchip,pins = <1 RK_PA4 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
@@ -116,6 +116,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &combphy0_ps {
 	status = "okay";
 };
@@ -184,9 +188,9 @@
 };
 
 &hdmi0 {
+	cec-enable;
 	enable-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
 	status = "okay";
-	cec-enable = "true";
 };
 
 &hdmi0_in_vp0 {
@@ -526,6 +530,10 @@
 	status = "okay";
 };
 
+&rkvtunnel {
+	status = "okay";
+};
+
 &avcc_1v8_s0 {
 	regulator-state-mem {
 		regulator-on-in-suspend;
@@ -667,6 +675,8 @@
 &vop {
 	assigned-clocks = <&cru ACLK_VOP>;
 	assigned-clock-rates = <800000000>;
+	vop-supply = <&vdd_log_s0>;
+	support-multi-area;
 	status = "okay";
 	disable-win-move;
 };
@@ -700,6 +710,29 @@
 	rockchip,primary-plane = <ROCKCHIP_VOP2_CLUSTER3>;
 };
 
+/* TODO: FE has those vps different: 
+&vp0 {
+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0)>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART0>;
+};
+
+&vp1 {
+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER1 | 1 << ROCKCHIP_VOP2_ESMART1)>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART1>;
+};
+
+&vp2 {
+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER2 | 1 << ROCKCHIP_VOP2_ESMART2)>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART2>;
+};
+
+&vp3 {
+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER3 | 1 << ROCKCHIP_VOP2_ESMART3)>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART3>;
+};
+*/
+
+
 &wdt {
 	status = "okay";
 };
@@ -708,3 +741,10 @@
 	clocks = <&hdptxphy_hdmi_clk0>;
 	clock-names = "hdmi0_phy_pll";
 };
+
+/* @TODO: FE has display_subsystem different:
+&display_subsystem {
+	clocks = <&hdptxphy_hdmi0>, <&hdptxphy_hdmi0>;
+	clock-names = "hdmi0_phy_pll", "hdmi1_phy_pll";
+};
+*/

--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6c.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6c.dts
@@ -24,5 +24,17 @@
 };
 
 &pcie2x1l2 {
+	rockchip,skip-hw-retry;
 	/delete-node/ pcie@40;
+};
+
+/* GPIO Connector */
+&pwm0 {
+	pinctrl-0 = <&pwm0m2_pins>;
+	status = "okay";
+};
+
+&pwm1 {
+	pinctrl-0 = <&pwm1m2_pins>;
+	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6s.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6s.dts
@@ -176,3 +176,13 @@
 	status = "okay";
 };
 
+
+&uart4 {
+	pinctrl-0 = <&uart4m2_xfer>;
+	status = "disabled";
+};
+
+&uart5 {
+	pinctrl-0 = <&uart5m1_xfer>;
+	status = "okay";
+};


### PR DESCRIPTION
#### arm64: dts: sync FriendlyElec's DTs from vendor source (common, R6S, R6C, T6, CM3588)

- From vendor's tree at https://github.com/friendlyarm/kernel-rockchip branch `nanopi6-v6.1.y` sha1 `925eb8ba4c765d4282a7281ddc6559a6e45c2687`
- adapt nomenclature, pull changes that seem to make sense, drop the ones we've explicitly done in Armbian fork

#### arm64: dts: add FriendlyElec's `rk3588-nanopc-t6-lts` DT

- the "T6 LTS" has a different regulator for USB2
- From vendor's tree at https://github.com/friendlyarm/kernel-rockchip branch `nanopi6-v6.1.y` sha1 `925eb8ba4c765d4282a7281ddc6559a6e45c2687`
- Adapted vendor's nomenclature (rev07 -> rk3588-nanopc-t6-lts.dts)
  - adapted include (rev01 -> rk3588-nanopc-t6.dts)
  - dropped `&mach` node that is vendor-specific
- this requires the `vcc5v0_host20_en` node added in previous commit to the `t6` DT
- add to Makefile