### PR TITLE
opi5pro: change dr_mode to host

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5-pro.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5-pro.dts
@@ -811,7 +811,7 @@
 
 &usbdrd_dwc3_0 {
 	status = "okay";
-	dr_mode = "otg";
+	dr_mode = "host";
 	extcon = <&u2phy0>;
 };
 


### PR DESCRIPTION
supposedly fixes usb3
untested, no hw


https://github.com/Joshua-Riek/linux-rockchip/commit/cc972a2683c329ad8454148134829123dc1c92e2

 https://forum.armbian.com/topic/43556-orange-pi-5-pro-usb-30-not-working-linux-orangepi5pro-6175/?do=findComment&comment=198709