### PR TITLE
arch: arm64: dts: fix armsom sige1 sd card boot

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3528-armsom-sige1.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3528-armsom-sige1.dts
@@ -83,7 +83,7 @@
 		regulator-name = "vccio_sd";
 		regulator-min-microvolt = <1800000>;
 		regulator-max-microvolt = <3300000>;
-		gpios = <&gpio4 RK_PC2 GPIO_ACTIVE_HIGH>;
+		gpios = <&gpio4 RK_PC2 GPIO_ACTIVE_LOW>;
 		vin-supply = <&vcc5v0_sys>;
 		states = <1800000 0x0
 			  3300000 0x1>;


### PR DESCRIPTION
ArmSoM sige can't boot with sd card before, and this will fix it.