### PR TITLE
Revert "PCI: rockchip: dw: remove .link_up() hook from struct dw_pcie…

### DIFF
--- a/drivers/pci/controller/dwc/pcie-dw-rockchip.c
+++ b/drivers/pci/controller/dwc/pcie-dw-rockchip.c
@@ -274,6 +274,18 @@ static inline void rk_pcie_enable_ltssm(struct rk_pcie *rk_pcie)
 	rk_pcie_writel_apb(rk_pcie, 0x0, 0xC000C);
 }
 
+static int rk_pcie_link_up(struct dw_pcie *pci)
+{
+	struct rk_pcie *rk_pcie = to_rk_pcie(pci);
+	u32 val;
+
+	val = rk_pcie_readl_apb(rk_pcie, PCIE_CLIENT_LTSSM_STATUS);
+	if ((val & (RDLH_LINKUP | SMLH_LINKUP)) == 0x30000)
+		return 1;
+
+	return 0;
+}
+
 static void rk_pcie_enable_debug(struct rk_pcie *rk_pcie)
 {
 	if (!IS_ENABLED(CONFIG_DEBUG_FS))
@@ -814,6 +826,7 @@ MODULE_DEVICE_TABLE(of, rk_pcie_of_match);
 
 static const struct dw_pcie_ops dw_pcie_ops = {
 	.start_link = rk_pcie_establish_link,
+	.link_up = rk_pcie_link_up,
 };
 
 static void rk_pcie_fast_link_setup(struct rk_pcie *rk_pcie)


### PR DESCRIPTION
There is one PCIe to SATA controller ASM1164 on ROCK 5 ITX.
This helps resolve the issue where SATA SSDs are sometimes not recognized on ROCK 5 ITX.

[AR-2434]

[AR-2434]: https://armbian.atlassian.net/browse/AR-2434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ