### PR TITLE
Fix and update GitHub Actions workflow for building the kernel on PR

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -15,14 +15,14 @@ jobs:
     steps:
       # Login to ghcr.io, for later uploading rootfs to ghcr.io
       - name: Docker Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }} # GitHub username or org
           password: ${{ secrets.GITHUB_TOKEN }} # GitHub actions builtin token. repo has to have pkg access.
 
       - name: Checkout build repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: armbian/build
           ref: main
@@ -47,7 +47,7 @@ jobs:
           ENABLE_EXTENSIONS="pull-request"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: linux-rockchip-vendor
           path: output/debs/*.deb

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -3,7 +3,7 @@ name: Build Kernels at PR
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, synchronize]
 
 jobs:
 

--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -1,4 +1,4 @@
-name: Build Kernels at PR
+name: Build kernel on PR
 
 on:
   workflow_dispatch:
@@ -6,32 +6,30 @@ on:
     types: [opened, synchronize]
 
 jobs:
-
   Build:
-    name: Compile kernel
+    name: Compile and upload kernel
     runs-on: rockchip
     if: ${{ github.repository_owner == 'armbian' }}
     env:
       OCI_TARGET_BASE: "ghcr.io/${{ github.repository }}/" # This is picked up by the Docker launcher automatically
     steps:
-
       # Login to ghcr.io, for later uploading rootfs to ghcr.io
       - name: Docker Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }} # GitHub username or org
-          password: ${{ secrets.GITHUB_TOKEN }}    # GitHub actions builtin token. repo has to have pkg access.
+          password: ${{ secrets.GITHUB_TOKEN }} # GitHub actions builtin token. repo has to have pkg access.
 
       - name: Checkout build repo
         uses: actions/checkout@v3
         with:
           repository: armbian/build
-          ref:  main
+          ref: main
           fetch-depth: 1
           clean: false
 
-      - name: Build Kernel at ${{ github.event.pull_request.head.sha }}
+      - name: Build kernel at ${{ github.event.pull_request.head.sha }}
         id: kernel
         run: |
 
@@ -48,7 +46,7 @@ jobs:
           BRANCH=vendor \
           ENABLE_EXTENSIONS="pull-request"
 
-      - name: Upload Artifact
+      - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: linux-rockchip-vendor


### PR DESCRIPTION
- Fix formatting and spelling
- Do not recompile kernel when PR comments are edited
  - The keyword "edited" refers to PR comments and titles, not to commits (see https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#pull_request)
  - Recompilation is not needed when a PR is closed and reopened, since `synchronize` will take care of any changes
- Update used Actions to their latest versions

This fixes deprecation warning on the workflow runs as well as prevents unneccessary runs when comments are edited.

Note: We should really set up Dependabot for the version bumps :)