### PR TITLE
rtc: rockchip: dts disable check add other variants

### DIFF
--- a/drivers/rtc/rtc-rk808.c
+++ b/drivers/rtc/rtc-rk808.c
@@ -417,7 +417,9 @@ static int rk808_rtc_probe(struct platform_device *pdev)
 	switch (rk808->variant) {
 	case RK805_ID:
 	case RK808_ID:
+	case RK809_ID:	
 	case RK816_ID:
+	case RK817_ID:	
 	case RK818_ID:
 		np = of_get_child_by_name(pdev->dev.parent->of_node, "rtc");
 		if (np && !of_device_is_available(np)) {


### PR DESCRIPTION
some  boards use the rtc node of pmic to disable its rtc  , the driver checked this  only for some variants
and ignored this for the other so it wasnt disabled as intended 