### PR TITLE
arm64: dts:  rock 3a  add spi flash, disable rk809 rtc and enable rockchip crypto device

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
@@ -410,6 +410,10 @@
 			status = "okay";
 		};
 
+		rtc {
+			status = "disabled";
+		};
+
 		pinctrl_rk8xx: pinctrl_rk8xx {
 			gpio-controller;
 			#gpio-cells = <2>;

--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
@@ -306,6 +306,10 @@
 	cpu-supply = <&vdd_cpu>;
 };
 
+&crypto {
+        status = "okay";
+};
+
 &dfi {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts
@@ -783,7 +783,34 @@
 };
 
 &sfc {
-	status = "okay";
+        status = "okay";
+        max-freq = <50000000>;
+        #address-cells = <1>;
+        #size-cells = <0>;
+        pinctrl-names = "default";
+        pinctrl-0 = <&fspi_pins>;
+
+        spi_flash: spi-flash@0 {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                compatible = "jedec,spi-nor";
+                reg = <0x0>;
+                spi-max-frequency = <50000000>;
+                spi-tx-bus-width = <1>;
+                spi-rx-bus-width = <4>;
+                status = "okay";
+
+				partitions {
+					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
+
+					loader@0 {
+						label = "loader";
+						reg = <0x0 0x1000000>;
+					};
+				};         
+		};
 };
 
 &tsadc {


### PR DESCRIPTION
changes:

- Added node for  spi nor  flash  
-  disable useless rk809 rtc ( because theres  another rtc hym8563 with battery connector )
-  enable rockchip crypto v2 device

tested with user-overlays:

-  flashed  u-boot to spi :   u-boot console and linux  boot works
-  rtc disabling works  dmesg output :  11.040702] rk808-rtc rk808-rtc: device is disabled
-  dmesg output crypto : rk-crypto fe380000.crypto: CRYPTO V2.0.0.0 Accelerator successfully registered

              

