### PR TITLE
arm64: dts: rock-3a:  add overlay to enable sata on m.2 e-key slot

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
@@ -18,6 +18,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	orangepi-5-pro-cam1.dtbo \
 	orangepi-5-pro-cam2.dtbo \
 	orangepi-5-pro-disable-leds.dtbo \
+	rock-3a-sata.dtbo \
 	rock-5a-hdmi-8k.dtbo \
 	rock-5a-i2c5-rtc-hym8563.dtbo \
 	rock-5a-radxa-camera-4k.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlay/rock-3a-sata.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/rock-3a-sata.dts
@@ -1,0 +1,27 @@
+// ROCK 3A Pcie M.2 to sata
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SATA2";
+		compatible = "radxa,rock-3a";
+		category = "misc";
+		description = "Enable SATA2.
+When SATA2 is enabled, PCIe cannot be enabled on the same port.";
+	};
+	
+	fragment@0 {
+		target = <&pcie2x1>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target = <&sata2>;
+		__overlay__ {
+			status = "okay";
+		};
+	};
+};


### PR DESCRIPTION
Add overlay to Switch the combophy in the  m.2 e-key  to SATA (source of overlay: radxa overlay repo)
Tested with m.2 e-key to m Key Adapter and SATA SSD