### PR TITLE
Review and refactor DTS code for Youyeetoo R1 V3

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-youyeetoo-r1.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-youyeetoo-r1.dts
@@ -52,7 +52,6 @@
 
     backlight: backlight {
         compatible = "pwm-backlight";
-        pwms = <&pwm12 0 25000 0>;
         brightness-levels = <
             0  20  20  21  21  22  22  23
             23  24  24  25  25  26  26  27
@@ -86,13 +85,12 @@
             232 233 234 235 236 237 238 239
             240 241 242 243 244 245 246 247
             248 249 250 251 252 253 254 255
-		>;
+        >;
         default-brightness-level = <200>;
-	};
+    };
 
-	backlight1: backlight1 {
+    backlight1: backlight1 {
         compatible = "pwm-backlight";
-        pwms = <&pwm11 0 25000 0>;
         brightness-levels = <
                 0  20  20  21  21  22  22  23
                 23  24  24  25  25  26  26  27
@@ -128,7 +126,7 @@
                 248 249 250 251 252 253 254 255
         >;
         default-brightness-level = <200>;
-	};
+    };
 
     /* BLUETOOTH */
     wireless_bluetooth: wireless-bluetooth {
@@ -149,28 +147,13 @@
     };
 
     /* FAN */
-    fan: gpio-fan {
-        compatible = "gpio-fan";
-        gpios = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;  /* Using GPIO0_C7 */
-        #cooling-cells = <2>;
-        cooling-levels = <0 50 100 150 200 255>;
-        gpio-fan,speed-map = <
-            0 0
-            1 50
-            2 100
-            3 150
-            4 200
-            5 255
-        >;
-        rockchip,temp-trips = <
-            50000    1
-            55000    2
-            60000    3
-            65000    4
-            70000    5
-        >;
-        status = "okay";
-    };
+	fan0: pwm-fan {
+		compatible = "pwm-fan";
+		#cooling-cells = <2>;
+		cooling-levels = <100 160 190 200 215 235 255>;
+		pwms = <&pwm6 0 40000 0>;
+        fan-supply = <&vcc12v_dcin>;
+	};
 };
 
 /* AUDIO */
@@ -182,8 +165,16 @@
 		     &i2s0_sdo0>;
 };
 
+/* PWM */
+&pwm6{
+     pinctrl-0 = <&pwm6m0_pins>;
+     pinctrl-names = "active";
+     status = "okay";
+};
+
 &pwm7{
      pinctrl-0 = <&pwm7m0_pins>;
+     pinctrl-names = "active";
      status = "okay";
 };
 
@@ -197,4 +188,18 @@
     status = "okay";
     pinctrl-names = "active";
     pinctrl-0 = <&pwm12m1_pins>;
+};
+
+/* LCD BACKLIGHT */
+
+&backlight {
+    pwms = <&pwm12 0 25000 0>;
+    status = "okay";
+    power-supply = <&vcc5v0_sys>;
+};
+
+&backlight1 {
+    pwms = <&pwm11 0 25000 0>;
+    status = "disabled";
+    power-supply = <&vcc5v0_sys>;
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588s-yyt-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-yyt-common.dtsi
@@ -160,7 +160,7 @@
 	leds: gpio-leds {
 		compatible = "gpio-leds";
 		pinctrl-names = "default";
-		pinctrl-0 =<&leds_gpio>;
+		pinctrl-0 = <&leds_gpio>;
 		status = "okay";
 
 		led@1 {
@@ -505,10 +505,86 @@
 };
 
 /* VARIOUS */
+/* FAN CONTROL */
 
+&threshold {
+	temperature = <60000>;
+};
+
+&soc_thermal {
+	sustainable-power = <5000>; /* milliwatts */
+	polling-delay = <1000>;
+	polling-delay-passive = <2000>;
+	trips {
+		trip0: trip-point@0 {
+			temperature = <55000>;
+			hysteresis = <5000>;
+			type = "active";
+		};
+		trip1: trip-point@1 {
+			temperature = <60000>;
+			hysteresis = <5000>;
+			type = "active";
+		};
+		trip2: trip-point@2 {
+			temperature = <65000>;
+			hysteresis = <5000>;
+			type = "active";
+		};
+		trip3: trip-point@3 {
+			temperature = <70000>;
+			hysteresis = <5000>;
+			type = "active";
+		};
+		trip4: trip-point@4 {
+			temperature = <75000>;
+			hysteresis = <5000>;
+			type = "active";
+		};
+		pcritical: trip-point@5 {
+			temperature = <80000>;
+			hysteresis = <1000>;
+			type = "active";
+		};
+	};
+	cooling-maps {
+		map0 {
+			trip = <&trip0>;
+			cooling-device = <&fan0 0 1>;
+			contribution = <1024>;
+		};
+		map1 {
+			trip = <&trip1>;
+			cooling-device = <&fan0 1 2>;
+			contribution = <1024>;
+		};
+		map2 {
+			trip = <&trip2>;
+			cooling-device = <&fan0 2 3>;
+			contribution = <1024>;
+		};
+		map3 {
+			trip = <&trip3>;
+			cooling-device = <&fan0 3 4>;
+			contribution = <1024>;
+		};
+		map4 {
+			trip = <&trip4>;
+			cooling-device = <&fan0 4 5>;
+			contribution = <1024>;
+		};
+		map5 {
+			trip = <&pcritical>;
+			cooling-device = <&fan0 5 6>;
+			contribution = <1024>;
+		};
+	};
+};
+
+/* CAN */
 &can2 {
     pinctrl-names = "default";
-    pinctrl-0 = <&can2m1_pins>;
+    pinctrl-0 = <&can2m0_pins>;
     status = "okay";
 };
 
@@ -728,6 +804,7 @@
 	tx_delay = <0x43>;
 
 	phy-handle = <&rgmii_phy1>;
+	phy-supply = <&vcc_3v3_s3>;
 };
 
 
@@ -814,7 +891,7 @@
 &uart5 {
         status = "okay";
         pinctrl-names = "default";
-        pinctrl-0 = <&uart5m1_xfer >;
+        pinctrl-0 = <&uart5m1_xfer>;
 };
 
 &pinctrl {
@@ -867,29 +944,10 @@
 			rockchip,pins = <0 RK_PA0 RK_FUNC_GPIO &pcfg_pull_down>;
 		};
 	};
-    /* GPIO KEYS */
-	gpio-key {
-        key1_pin: key1-pin {
-            rockchip,pins = <1 RK_PC0 RK_FUNC_GPIO &pcfg_pull_up>;
-        };
+    /* GPIO */
+	gpio {
 		leds_gpio: leds-gpio {
 			rockchip,pins = <0 RK_PC5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
-    };
-
-    xgpio {
-        gpio_4g:gpio-4g{
-                rockchip,pins =
-					<0 23  RK_FUNC_GPIO &pcfg_pull_up>;
-					//<3 26 RK_FUNC_GPIO &pcfg_pull_up>,
-					//<3 27 RK_FUNC_GPIO &pcfg_pull_up>,
-					//<0 21 RK_FUNC_GPIO &pcfg_pull_up>,
-					//<0 29 RK_FUNC_GPIO &pcfg_pull_up>,
-					//<4 6  RK_FUNC_GPIO &pcfg_pull_up>,
-					//<4 7  RK_FUNC_GPIO &pcfg_pull_up>,
-					//<0 8  RK_FUNC_GPIO &pcfg_pull_up>;
-					//<4 10  RK_FUNC_GPIO &pcfg_pull_none>,
-					//<4 13 RK_FUNC_GPIO &pcfg_pull_up>;
-        };
     };
 };


### PR DESCRIPTION
- Reworked FAN code for improved support; now correctly operates when the temperature reaches 55°C.
- Fixed CAN pinctrl interface; pin assignment aligned with the schematic.
- Added PHY supply reference to Ethernet configuration.
- Removed redundant code, including xgpio on pinctrl.
- Renamed `gpio-key` to `gpio` for clearer reference.
- Moved LCD backlight PWM controls to the appropriate function.