### PR TITLE
arch: arm64: dts: fix sdio wifi clk for armsom-sige1

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3528-armsom-sige1.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3528-armsom-sige1.dts
@@ -253,7 +253,7 @@
 	sdio_pwrseq: sdio-pwrseq {
 		compatible = "mmc-pwrseq-simple";
 		pinctrl-names = "default";
-		pinctrl-0 = <&wifi_enable_h &clkm0_32k_out>;
+		pinctrl-0 = <&wifi_enable_h &clkm1_32k_out>;
 		reset-gpios = <&gpio1 RK_PA6 GPIO_ACTIVE_LOW>;
 	};
 


### PR DESCRIPTION
New version of armsom sige1 is using bcm43752(ap6275s) as wifi/bt module, and the origin dts has a wrong clk.
This fix will let armsom make use of mainline wifi driver.