### PR TITLE
Add reserved-memory node for hdmirx-controller on Youyeetoo R1 v3

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-youyeetoo-r1.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-youyeetoo-r1.dts
@@ -154,6 +154,21 @@
 		pwms = <&pwm6 0 40000 0>;
         fan-supply = <&vcc12v_dcin>;
 	};
+
+    /* If hdmirx node is disabled, delete the reserved-memory node here. */
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		/* Reserve 256MB memory for hdmirx-controller@fdee0000 */
+		cma {
+			compatible = "shared-dma-pool";
+			reusable;
+			reg = <0x0 (256 * 0x100000) 0x0 (256 * 0x100000)>;
+			linux,cma-default;
+		};
+	};
 };
 
 /* AUDIO */


### PR DESCRIPTION
This should be fix this error:

[ 1234.879663] cma: cma_alloc: cma: alloc failed, req-size: 512 pages, ret: -12
