### PR TITLE
boogie's vop2 rbga2101010 capability fix (6.1-rkr3 adapted version)

### DIFF
--- a/drivers/gpu/drm/rockchip/rockchip_vop2_reg.c
+++ b/drivers/gpu/drm/rockchip/rockchip_vop2_reg.c
@@ -31,8 +31,6 @@
 		_VOP_REG(off, _mask, s, true)
 
 static const uint32_t formats_for_cluster[] = {
-	DRM_FORMAT_XRGB2101010,
-	DRM_FORMAT_XBGR2101010,
 	DRM_FORMAT_XRGB8888,
 	DRM_FORMAT_ARGB8888,
 	DRM_FORMAT_XBGR8888,


### PR DESCRIPTION
- from https://raw.githubusercontent.com/wiki/hbiyik/ffmpeg-rockchip/patches/rockchip-kernel/0002-vop2_rgba2101010_capability_fix.patch -- adapted for 6.1-rkr3 where half of it was gone already

See https://github.com/nyanmisaka/ffmpeg-rockchip/wiki/Rendering#required-patches-and-fixes-in-the-toolchain

> "When using Kodi in GBM Mode, you will get a black screen if this patch is not applied. This is a bug in rockchip kernel."
