### PR TITLE
Fix error on load Headphone on NanoPC T6

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
@@ -57,11 +57,11 @@
 		simple-audio-card,hp-pin-name = "Headphone Jack";
 
 		simple-audio-card,widgets =
-			"Headphone", "Headphone Jack",
+			"Headphone", "Headphones",
 			"Microphone", "Microphone Jack";
 		simple-audio-card,routing =
-			"Headphone Jack", "HPOL",
-			"Headphone Jack", "HPOR",
+			"Headphones", "HPOL",
+			"Headphones", "HPOR",
 			"MIC1", "Microphone Jack",
 			"Microphone Jack", "micbias1";
 


### PR DESCRIPTION
This commit fixes issue #219, I have tried the speaker test and it is working correctly.
Reference error:
- asoc-simple-card rt5616-sound: ASoC: DAPM unknown pin Headphones