### PR TITLE
arm64: rockchip: add YX35 LCD overlays for NanoPi M6

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
@@ -71,6 +71,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	khadas-edge2-cam1.dtbo \
 	khadas-edge2-cam2.dtbo \
 	khadas-edge2-cam3.dtbo \
+	nanopi-m6-display-dsi0-yx35.dtbo \
+	nanopi-m6-display-dsi1-yx35.dtbo \
 	rockchip-rk3588-opp-oc-24ghz.dtbo \
 	rockchip-rk3588-panthor-gpu.dtbo \
 	rk3566-roc-pc-sata2.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlay/nanopi-m6-display-dsi0-yx35.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/nanopi-m6-display-dsi0-yx35.dts
@@ -1,0 +1,249 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/display/drm_mipi_dsi.h>
+
+/ {
+	fragment@0 {
+		target = <&pwm_backlight>;
+
+		__overlay__ {
+			brightness-levels = <
+        		  0  20  20  21  21  22  22  23
+        		 23  24  24  25  25  26  26  27
+        		 27  28  28  29  29  30  30  31
+        		 31  32  32  33  33  34  34  35
+        		 35  36  36  37  37  38  38  39
+        		 40  41  42  43  44  45  46  47
+        		 48  49  50  51  52  53  54  55
+        		 56  57  58  59  60  61  62  63
+        		 64  65  66  67  68  69  70  71
+        		 72  73  74  75  76  77  78  79
+        		 80  81  82  83  84  85  86  87
+        		 88  89  90  91  92  93  94  95
+        		 96  97  98  99 100 101 102 103
+        		104 105 106 107 108 109 110 111
+        		112 113 114 115 116 117 118 119
+        		120 121 122 123 124 125 126 127
+        		128 129 130 131 132 133 134 135
+        		136 137 138 139 140 141 142 143
+        		144 145 146 147 148 149 150 151
+        		152 153 154 155 156 157 158 159
+        		160 161 162 163 164 165 166 167
+        		168 169 170 171 172 173 174 175
+        		176 177 178 179 180 181 182 183
+        		184 185 186 187 188 189 190 191
+        		192 193 194 195 196 197 198 199
+        		200 201 202 203 204 205 206 207
+        		208 209 210 211 212 213 214 215
+        		216 217 218 219 220 221 222 223
+        		224 225 226 227 228 229 230 231
+        		232 233 234 235 236 237 238 239
+        		240 241 242 243 244 245 246 247
+        		248 249 250 251 252 253 254 255
+        	>;
+        	default-brightness-level = <200>;
+        	pwms = <&pwm10 0 25000 0>;
+            status = "okay";
+		};	
+	};
+
+	fragment@1 {
+		target = <&pwm10>;
+
+		__overlay__ {
+			pinctrl-0 = <&pwm10m2_pins>;
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&mipi_dcphy0>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&i2c4>;
+
+		__overlay__ {
+			clock-frequency = <200000>;
+        	pinctrl-0 = <&i2c4m3_xfer>;
+        	status = "okay";
+        
+        	dsi0_gt1x: gt1x@14 {
+        		compatible = "goodix,gt1x";
+        		reg = <0x14>;
+        		pinctrl-names = "default";
+				pinctrl-0 = <&touch_dsi0_gpio>;
+				interrupt-parent = <&gpio3>;
+				interrupts = <RK_PC0 IRQ_TYPE_EDGE_FALLING>;
+				goodix,irq-gpio = <&gpio3 RK_PC0 IRQ_TYPE_EDGE_FALLING>;
+				goodix,rst-gpio = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
+        		keep-otp-config;
+        		status = "okay";
+        	};
+        
+        	dsi0_e2prom: eeprom@50 {
+        		compatible = "microchip,24c02", "atmel,24c02";
+        		reg = <0x50>;
+        		#address-cells = <2>;
+        		#size-cells = <0>;
+        		pagesize = <16>;
+        		size = <256>;
+        		status = "okay";
+        	};
+		};
+	};
+
+
+	fragment@4 {
+		target = <&route_dsi0>;
+
+		__overlay__ {
+			connect = <&vp2_out_dsi0>;
+			status = "okay";
+		};
+	};
+
+	fragment@5 {
+		target = <&dsi0_in_vp2>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@6 {
+		target = <&dsi0>;
+
+		__overlay__ {
+			status = "okay";
+        	dsi0_panel: panel@0 {
+        		compatible = "simple-panel-dsi";
+        		reg = <0>;
+        
+        		backlight = <&pwm_backlight>;
+        		pinctrl-names = "default";
+        		pinctrl-0 = <&lcd_rst0_gpio>;
+        		reset-gpios = <&gpio3 RK_PD2 GPIO_ACTIVE_LOW>;
+        		panel-name = "yx35,210dpi";
+        		nvmems = <&dsi0_i2c 0x50 0xe0 0x10>;
+        		nvmem-status = <1>;
+        
+        		reset-delay-ms = <20>;
+        		init-delay-ms = <120>;
+        		enable-delay-ms = <5>;
+        		prepare-delay-ms = <0>;
+        		unprepare-delay-ms = <10>;
+        		disable-delay-ms = <5>;
+        		width-mm = <45>;
+        		height-mm = <75>;
+        
+        		dsi,flags = <(MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
+        			      MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS)>;
+        		dsi,format = <MIPI_DSI_FMT_RGB888>;
+        		dsi,lanes  = <2>;
+        		panel-init-sequence = [
+        			15 0A 02 01 00
+        			15 7D 02 11 00
+        			39 00 06 FF 77 01 00 00 13
+        			15 00 02 EF 08
+        			39 00 06 FF 77 01 00 00 10
+        			39 00 03 C0 63 00
+        			39 00 03 C1 14 14
+        			39 00 03 C2 37 02
+        			15 00 02 CC 10
+        			39 00 11 B0 C5 11 1B 0D 11 07 0A 09 08 24 05 12 10 A9 32 DF
+        			39 00 11 B1 C5 19 21 0B 0E 03 0C 07 07 26 04 12 11 AA 32 DF
+        			39 00 06 FF 77 01 00 00 11
+        			15 00 02 B0 4D
+        			15 00 02 B1 59
+        			15 00 02 B2 81
+        			15 00 02 B3 80
+        			15 00 02 B5 4E
+        			15 00 02 B7 85
+        			15 00 02 B8 32
+        			15 00 02 BB 03
+        			15 00 02 C1 08
+        			15 00 02 C2 08
+        			15 00 02 D0 88
+        			39 00 04 E0 00 00 02
+        			39 00 0C E1 06 28 08 28 05 28 07 28 0E 33 33
+        			39 00 0D E2 30 30 33 33 34 00 00 00 34 00 00 00
+        			39 00 05 E3 00 00 33 33
+        			39 00 03 E4 44 44
+        			39 00 11 E5 09 2F 2C 8C 0B 31 2C 8C 0D 33 2C 8C 0F 35 2C 8C
+        			39 00 05 E6 00 00 33 33
+        			39 00 03 E7 44 44
+        			39 00 11 E8 08 2E 2C 8C 0A 30 2C 8C 0C 32 2C 8C 0E 34 2C 8C
+        			39 00 03 E9 36 00
+        			39 00 08 EB 00 01 E4 E4 44 88 40
+        			39 00 11 ED FF FC B2 45 67 FA 01 FF FF 10 AF 76 54 2B CF FF
+        			39 00 07 EF 08 08 08 45 3F 54
+        			39 00 06 FF 77 01 00 00 13
+        			39 00 03 E8 00 0E
+        			15 78 02 11 00
+        			39 0A 03 E8 00 0C
+        			39 00 03 E8 00 00
+        			39 00 06 FF 77 01 00 00 00
+        			15 00 02 36 00
+        			15 00 02 29 00
+        		];
+        
+        		panel-exit-sequence = [
+        			15 00 02 28 00
+        			15 3C 02 10 00
+        		];
+        
+        		disp_timings0: display-timings {
+        			native-mode = <&dsi_timing0>;
+        			dsi_timing0: timing0 {
+        				clock-frequency = <29700000>;
+        				hactive = <480>;
+        				vactive = <800>;
+        				hfront-porch = <40>;
+        				hsync-len = <32>;
+        				hback-porch = <30>;
+        				vfront-porch = <20>;
+        				vsync-len = <10>;
+        				vback-porch = <20>;
+        				hsync-active = <0>;
+        				vsync-active = <0>;
+        				de-active = <0>;
+        				pixelclk-active = <0>;
+        			};
+        		};
+        
+        		ports {
+        			#address-cells = <1>;
+        			#size-cells = <0>;
+        
+        			port@0 {
+        				reg = <0>;
+        				panel_in_dsi0: endpoint {
+        					remote-endpoint = <&dsi0_out_panel>;
+        				};
+        			};
+        		};
+        	};
+        
+        	ports {
+        		#address-cells = <1>;
+        		#size-cells = <0>;
+        
+        		port@1 {
+        			reg = <1>;
+        			dsi0_out_panel: endpoint {
+        				remote-endpoint = <&panel_in_dsi0>;
+        			};
+        		};
+        	};
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/overlay/nanopi-m6-display-dsi1-yx35.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/nanopi-m6-display-dsi1-yx35.dts
@@ -1,0 +1,249 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/display/drm_mipi_dsi.h>
+
+/ {
+	fragment@0 {
+		target = <&pwm_backlight>;
+
+		__overlay__ {
+			brightness-levels = <
+        		  0  20  20  21  21  22  22  23
+        		 23  24  24  25  25  26  26  27
+        		 27  28  28  29  29  30  30  31
+        		 31  32  32  33  33  34  34  35
+        		 35  36  36  37  37  38  38  39
+        		 40  41  42  43  44  45  46  47
+        		 48  49  50  51  52  53  54  55
+        		 56  57  58  59  60  61  62  63
+        		 64  65  66  67  68  69  70  71
+        		 72  73  74  75  76  77  78  79
+        		 80  81  82  83  84  85  86  87
+        		 88  89  90  91  92  93  94  95
+        		 96  97  98  99 100 101 102 103
+        		104 105 106 107 108 109 110 111
+        		112 113 114 115 116 117 118 119
+        		120 121 122 123 124 125 126 127
+        		128 129 130 131 132 133 134 135
+        		136 137 138 139 140 141 142 143
+        		144 145 146 147 148 149 150 151
+        		152 153 154 155 156 157 158 159
+        		160 161 162 163 164 165 166 167
+        		168 169 170 171 172 173 174 175
+        		176 177 178 179 180 181 182 183
+        		184 185 186 187 188 189 190 191
+        		192 193 194 195 196 197 198 199
+        		200 201 202 203 204 205 206 207
+        		208 209 210 211 212 213 214 215
+        		216 217 218 219 220 221 222 223
+        		224 225 226 227 228 229 230 231
+        		232 233 234 235 236 237 238 239
+        		240 241 242 243 244 245 246 247
+        		248 249 250 251 252 253 254 255
+        	>;
+        	default-brightness-level = <200>;
+        	pwms = <&pwm11 0 25000 0>;
+            status = "okay";
+		};	
+	};
+
+	fragment@1 {
+		target = <&pwm11>;
+
+		__overlay__ {
+			pinctrl-0 = <&pwm11m3_pins>;
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&mipi_dcphy1>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&i2c5>;
+
+		__overlay__ {
+			clock-frequency = <200000>;
+        	pinctrl-0 = <&i2c5m2_xfer>;
+        	status = "okay";
+        
+        	dsi1_gt1x: gt1x@14 {
+        		compatible = "goodix,gt1x";
+        		reg = <0x14>;
+        		pinctrl-names = "default";
+        		pinctrl-0 = <&touch_dsi1_gpio>;
+        		interrupt-parent = <&gpio4>;
+        		interrupts = <RK_PA0 IRQ_TYPE_EDGE_FALLING>;
+        		goodix,irq-gpio = <&gpio4 RK_PA0 IRQ_TYPE_EDGE_FALLING>;
+        		goodix,rst-gpio = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
+        		keep-otp-config;
+        		status = "okay";
+        	};
+        
+        	dsi1_e2prom: eeprom@50 {
+        		compatible = "microchip,24c02", "atmel,24c02";
+        		reg = <0x50>;
+        		#address-cells = <2>;
+        		#size-cells = <0>;
+        		pagesize = <16>;
+        		size = <256>;
+        		status = "okay";
+        	};
+		};
+	};
+
+
+	fragment@4 {
+		target = <&route_dsi1>;
+
+		__overlay__ {
+			connect = <&vp2_out_dsi1>;
+			status = "okay";
+		};
+	};
+
+	fragment@5 {
+		target = <&dsi1_in_vp2>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@6 {
+		target = <&dsi1>;
+
+		__overlay__ {
+			status = "okay";
+        	dsi1_panel: panel@0 {
+        		compatible = "simple-panel-dsi";
+        		reg = <0>;
+        
+        		backlight = <&pwm_backlight>;
+        		pinctrl-names = "default";
+        		pinctrl-0 = <&lcd_rst1_gpio>;
+        		reset-gpios = <&gpio4 RK_PA1 GPIO_ACTIVE_LOW>;
+        		panel-name = "yx35,210dpi";
+        		nvmems = <&i2c5 0x50 0xe0 0x10>;
+        		nvmem-status = <1>;
+        
+        		reset-delay-ms = <20>;
+        		init-delay-ms = <120>;
+        		enable-delay-ms = <5>;
+        		prepare-delay-ms = <0>;
+        		unprepare-delay-ms = <10>;
+        		disable-delay-ms = <5>;
+        		width-mm = <45>;
+        		height-mm = <75>;
+        
+        		dsi,flags = <(MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
+        			      MIPI_DSI_MODE_LPM | MIPI_DSI_CLOCK_NON_CONTINUOUS)>;
+        		dsi,format = <MIPI_DSI_FMT_RGB888>;
+        		dsi,lanes  = <2>;
+        		panel-init-sequence = [
+        			15 0A 02 01 00
+        			15 7D 02 11 00
+        			39 00 06 FF 77 01 00 00 13
+        			15 00 02 EF 08
+        			39 00 06 FF 77 01 00 00 10
+        			39 00 03 C0 63 00
+        			39 00 03 C1 14 14
+        			39 00 03 C2 37 02
+        			15 00 02 CC 10
+        			39 00 11 B0 C5 11 1B 0D 11 07 0A 09 08 24 05 12 10 A9 32 DF
+        			39 00 11 B1 C5 19 21 0B 0E 03 0C 07 07 26 04 12 11 AA 32 DF
+        			39 00 06 FF 77 01 00 00 11
+        			15 00 02 B0 4D
+        			15 00 02 B1 59
+        			15 00 02 B2 81
+        			15 00 02 B3 80
+        			15 00 02 B5 4E
+        			15 00 02 B7 85
+        			15 00 02 B8 32
+        			15 00 02 BB 03
+        			15 00 02 C1 08
+        			15 00 02 C2 08
+        			15 00 02 D0 88
+        			39 00 04 E0 00 00 02
+        			39 00 0C E1 06 28 08 28 05 28 07 28 0E 33 33
+        			39 00 0D E2 30 30 33 33 34 00 00 00 34 00 00 00
+        			39 00 05 E3 00 00 33 33
+        			39 00 03 E4 44 44
+        			39 00 11 E5 09 2F 2C 8C 0B 31 2C 8C 0D 33 2C 8C 0F 35 2C 8C
+        			39 00 05 E6 00 00 33 33
+        			39 00 03 E7 44 44
+        			39 00 11 E8 08 2E 2C 8C 0A 30 2C 8C 0C 32 2C 8C 0E 34 2C 8C
+        			39 00 03 E9 36 00
+        			39 00 08 EB 00 01 E4 E4 44 88 40
+        			39 00 11 ED FF FC B2 45 67 FA 01 FF FF 10 AF 76 54 2B CF FF
+        			39 00 07 EF 08 08 08 45 3F 54
+        			39 00 06 FF 77 01 00 00 13
+        			39 00 03 E8 00 0E
+        			15 78 02 11 00
+        			39 0A 03 E8 00 0C
+        			39 00 03 E8 00 00
+        			39 00 06 FF 77 01 00 00 00
+        			15 00 02 36 00
+        			15 00 02 29 00
+        		];
+        
+        		panel-exit-sequence = [
+        			15 00 02 28 00
+        			15 3C 02 10 00
+        		];
+        
+        		display-timings {
+        			native-mode = <&dsi1_timing0>;
+        			dsi1_timing0: timing0 {
+        				clock-frequency = <29700000>;
+        				hactive = <480>;
+        				vactive = <800>;
+        				hfront-porch = <40>;
+        				hsync-len = <32>;
+        				hback-porch = <30>;
+        				vfront-porch = <20>;
+        				vsync-len = <10>;
+        				vback-porch = <20>;
+        				hsync-active = <0>;
+        				vsync-active = <0>;
+        				de-active = <0>;
+        				pixelclk-active = <0>;
+        			};
+        		};
+        
+        		ports {
+        			#address-cells = <1>;
+        			#size-cells = <0>;
+        
+        			port@0 {
+        				reg = <0>;
+        				panel_in_dsi1: endpoint {
+        					remote-endpoint = <&dsi1_out_panel>;
+        				};
+        			};
+        		};
+        	};
+        
+        	ports {
+        		#address-cells = <1>;
+        		#size-cells = <0>;
+        
+        		port@1 {
+        			reg = <1>;
+        			dsi1_out_panel: endpoint {
+        				remote-endpoint = <&panel_in_dsi1>;
+        			};
+        		};
+        	};
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-m6.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-m6.dts
@@ -133,6 +133,11 @@
 		regulator-max-microvolt = <5000000>;
 		vin-supply = <&vcc5v0_usb>;
 	};
+
+	pwm_backlight: pwm-backlight {
+		status = "disabled";
+		compatible = "pwm-backlight";
+	};
 };
 
 
@@ -220,18 +225,6 @@
 	};
 };
 
-// DSI0 I2C
-&i2c4 {
-	clock-frequency = <200000>;
-	pinctrl-0 = <&i2c4m3_xfer>;
-};
-
-// DSI1 I2C
-&i2c5 {
-	clock-frequency = <200000>;
-	pinctrl-0 = <&i2c5m2_xfer>;
-};
-
 // EEPROM is not mounted by default.
 &i2c6 {
 	clock-frequency = <200000>;
@@ -283,16 +276,6 @@
 &pwm5 {
 	pinctrl-0 = <&pwm5m1_pins>;
 	status = "okay";
-};
-
-// DSI0 PWM
-&pwm10 {
-	pinctrl-0 = <&pwm10m2_pins>;
-};
-
-// DSI1 PWM
-&pwm11 {
-	pinctrl-0 = <&pwm11m3_pins>;
 };
 
 &u2phy0_otg {

--- a/drivers/gpu/drm/rockchip/rockchip_drm_logo.c
+++ b/drivers/gpu/drm/rockchip/rockchip_drm_logo.c
@@ -909,6 +909,11 @@ static int setup_initial_state(struct drm_device *drm_dev,
 			primary_state->crtc_y = (vdisplay - fb_height) / 2;
 			primary_state->crtc_h = fb_height;
 		}
+
+		if (set->fb->width > hdisplay) {
+			primary_state->crtc_h = (set->fb->height * hdisplay) / set->fb->width;
+			primary_state->crtc_y = (vdisplay - primary_state->crtc_h) / 2;
+		}
 	} else {
 		primary_state->crtc_x = 0;
 		primary_state->crtc_y = 0;

--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
+++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
@@ -5373,9 +5373,10 @@ static int vop2_plane_atomic_check(struct drm_plane *plane, struct drm_atomic_st
 
 	if (drm_rect_width(src) >> 16 < 4 || drm_rect_height(src) >> 16 < 4 ||
 	    drm_rect_width(dest) < 4 || drm_rect_width(dest) < 4) {
-		DRM_ERROR("Invalid size: %dx%d->%dx%d, min size is 4x4\n",
-			  drm_rect_width(src) >> 16, drm_rect_height(src) >> 16,
-			  drm_rect_width(dest), drm_rect_height(dest));
+		if (plane->type != DRM_PLANE_TYPE_CURSOR)
+			DRM_ERROR("Invalid size: %dx%d->%dx%d, min size is 4x4\n",
+				  drm_rect_width(src) >> 16, drm_rect_height(src) >> 16,
+				  drm_rect_width(dest), drm_rect_height(dest));
 		pstate->visible = false;
 		return 0;
 	}

--- a/drivers/input/touchscreen/gt1x/gt1x.c
+++ b/drivers/input/touchscreen/gt1x/gt1x.c
@@ -364,6 +364,12 @@ static int gt1x_parse_dt(struct device *dev)
 	}
 #endif
 
+#if GTP_DRIVER_SEND_CFG
+	gt1x_keep_otp_config = of_property_read_bool(dev->of_node, "keep-otp-config");
+#else
+	gt1x_keep_otp_config = true;
+#endif
+
 	return 0;
 }
 

--- a/drivers/input/touchscreen/gt1x/gt1x_generic.h
+++ b/drivers/input/touchscreen/gt1x/gt1x_generic.h
@@ -534,6 +534,7 @@ extern s32 gt1x_i2c_read(u16 addr, u8 *buffer, s32 len);
 extern s32 gt1x_i2c_read_dbl_check(u16 addr, u8 *buffer, s32 len);
 
 extern bool gt1x_ics_slot_report;
+extern bool gt1x_keep_otp_config;
 extern u8 gt1x_config[];
 extern u32 gt1x_cfg_length;
 extern u8 gt1x_int_type;


### PR DESCRIPTION
Add support for 3.5" LCD screen which is found on NanoPi M6