### PR TITLE
power: supply: add Simple ADC power supply driver for NanoPi boards

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-nanopi5-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3568-nanopi5-common.dtsi
@@ -235,8 +235,8 @@
 		voltage-min-design-microvolt = <4500000>;
 	};
 
-	simple_vin: simple-vin {
-		compatible = "simple-adc-power-v1";
+	nanopi_adc_vin: nanopi-adc-vin {
+		compatible = "nanopi-adc-power-v1";
 		io-channels = <&saradc 2>;
 		io-channel-names = "voltage";
 		monitored-battery = <&simple_bat>;

--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
@@ -103,6 +103,19 @@
 		vin-supply = <&vcc5v0_usb>;
 	};
 
+	simple_bat: battery {
+		compatible = "simple-battery";
+		voltage-max-design-microvolt = <21000000>;
+		voltage-min-design-microvolt = <4500000>;
+	};
+
+	nanopi_adc_vin: nanopi-adc-vin {
+		compatible = "nanopi-adc-power-v2";
+		io-channels = <&saradc 2>;
+		io-channel-names = "voltage";
+		monitored-battery = <&simple_bat>;
+	};
+
 	test-power {
 		status = "okay";
 	};

--- a/drivers/power/supply/Kconfig
+++ b/drivers/power/supply/Kconfig
@@ -1013,4 +1013,12 @@ config BATTERY_UG3105
 	  device is off or suspended, the functionality of this driver is
 	  limited to reporting capacity only.
 
+config NANOPI_ADC_POWER
+	tristate "Simple ADC power supply driver for NanoPi 5/6 series"
+	depends on IIO
+	help
+	  Say Y here to enable support for the simple power supply driver
+	  which uses IIO framework to read adc on NanoPi 5/6 series boards.
+
+
 endif # POWER_SUPPLY

--- a/drivers/power/supply/Makefile
+++ b/drivers/power/supply/Makefile
@@ -121,3 +121,5 @@ obj-$(CONFIG_BATTERY_ACER_A500)	+= acer_a500_battery.o
 obj-$(CONFIG_BATTERY_SURFACE)	+= surface_battery.o
 obj-$(CONFIG_CHARGER_SURFACE)	+= surface_charger.o
 obj-$(CONFIG_BATTERY_UG3105)	+= ug3105_battery.o
+
+obj-$(CONFIG_NANOPI_ADC_POWER)	+= nanopi_adc_power.o

--- a/drivers/power/supply/nanopi_adc_power.c
+++ b/drivers/power/supply/nanopi_adc_power.c
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Simple ADC power supply driver
+ *
+ * Copyright (c) 2024 FriendlyElec Computer Tech. Co., Ltd.
+ * (http://www.friendlyelec.com)
+ *
+ * based on ingenic-battery.c
+ */
+
+#include <linux/iio/consumer.h>
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/of_device.h>
+#include <linux/platform_device.h>
+#include <linux/power_supply.h>
+
+struct nanopi_adc_power_priv {
+	struct device *dev;
+	struct iio_channel *iio_v;
+	struct power_supply_desc desc;
+	struct power_supply *psy;
+	struct power_supply_battery_info *info;
+	const struct nanopi_adc_platform_data *pdata;
+	int online;
+};
+
+struct nanopi_adc_platform_data {
+	int (*to_voltage)(int raw);
+};
+
+static int nanopi_adc_power_get_property(struct power_supply *psy,
+					 enum power_supply_property psp,
+					 union power_supply_propval *val)
+{
+	struct nanopi_adc_power_priv *priv = power_supply_get_drvdata(psy);
+	struct power_supply_battery_info *info = priv->info;
+	int raw = 0;
+	int ret;
+
+	switch (psp) {
+	case POWER_SUPPLY_PROP_HEALTH:
+		ret = iio_read_channel_raw(priv->iio_v, &raw);
+		val->intval = priv->pdata->to_voltage(raw);
+		if (val->intval < info->voltage_min_design_uv)
+			val->intval = POWER_SUPPLY_HEALTH_DEAD;
+		else if (val->intval > info->voltage_max_design_uv)
+			val->intval = POWER_SUPPLY_HEALTH_OVERVOLTAGE;
+		else
+			val->intval = POWER_SUPPLY_HEALTH_GOOD;
+		return ret < 0 ? ret : 0;
+	case POWER_SUPPLY_PROP_ONLINE:
+		val->intval = priv->online;
+		return 0;
+	case POWER_SUPPLY_PROP_VOLTAGE_NOW:
+		ret = iio_read_channel_raw(priv->iio_v, &raw);
+		val->intval = priv->pdata->to_voltage(raw);
+		return ret < 0 ? ret : 0;
+	case POWER_SUPPLY_PROP_VOLTAGE_MIN_DESIGN:
+		val->intval = info->voltage_min_design_uv;
+		return 0;
+	case POWER_SUPPLY_PROP_VOLTAGE_MAX_DESIGN:
+		val->intval = info->voltage_max_design_uv;
+		return 0;
+	default:
+		return -EINVAL;
+	}
+}
+
+static enum power_supply_property nanopi_adc_power_properties[] = {
+	POWER_SUPPLY_PROP_HEALTH,
+	POWER_SUPPLY_PROP_ONLINE,
+	POWER_SUPPLY_PROP_VOLTAGE_NOW,
+	POWER_SUPPLY_PROP_VOLTAGE_MIN_DESIGN,
+	POWER_SUPPLY_PROP_VOLTAGE_MAX_DESIGN,
+};
+
+static int nanopi_adc_to_voltage_v1(int raw)
+{
+	int mv = 5000;
+
+	if (raw > 160 && raw < 1024) {
+		mv = raw * 196 - 2130;
+		mv /= 10;
+	}
+
+	return (mv * 1000);
+}
+
+static int nanopi_adc_to_voltage_v2(int raw)
+{
+	int mv = raw * 2475 / 512;
+
+	return (mv * 1000);
+}
+
+static const struct nanopi_adc_platform_data nanopi_adc_pdata_v1 = {
+	.to_voltage = nanopi_adc_to_voltage_v1,
+};
+
+static const struct nanopi_adc_platform_data nanopi_adc_pdata_v2 = {
+	.to_voltage = nanopi_adc_to_voltage_v2,
+};
+
+static const struct of_device_id nanopi_adc_power_of_match[] = {
+	{ .compatible = "nanopi-adc-power-v1", .data = &nanopi_adc_pdata_v1 },
+	{ .compatible = "nanopi-adc-power-v2", .data = &nanopi_adc_pdata_v2 },
+	{},
+};
+MODULE_DEVICE_TABLE(of, nanopi_adc_power_of_match);
+
+static int nanopi_adc_power_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	const struct of_device_id *match;
+	struct nanopi_adc_power_priv *priv;
+	struct power_supply_config psy_cfg = {};
+	struct power_supply_desc *desc;
+	int ret;
+
+	match = of_match_device(nanopi_adc_power_of_match, dev);
+	if (!match || !match->data)
+		return -ENODEV;
+
+	priv = devm_kzalloc(dev, sizeof(*priv), GFP_KERNEL);
+	if (!priv)
+		return -ENOMEM;
+
+	priv->dev = dev;
+	priv->online = 1;
+	priv->pdata = match->data;
+
+	priv->iio_v = devm_iio_channel_get(dev, "voltage");
+	if (IS_ERR(priv->iio_v))
+		return PTR_ERR(priv->iio_v);
+
+	desc = &priv->desc;
+	desc->name = dev_name(dev);
+	desc->type = POWER_SUPPLY_TYPE_MAINS;
+	desc->properties = nanopi_adc_power_properties;
+	desc->num_properties = ARRAY_SIZE(nanopi_adc_power_properties);
+	desc->get_property = nanopi_adc_power_get_property;
+
+	psy_cfg.drv_data = priv;
+	psy_cfg.of_node = dev->of_node;
+
+	priv->psy = devm_power_supply_register(dev, desc, &psy_cfg);
+	if (IS_ERR(priv->psy))
+		return dev_err_probe(dev, PTR_ERR(priv->psy),
+				     "Unable to register supply\n");
+
+	ret = power_supply_get_battery_info(priv->psy, &priv->info);
+	if (ret) {
+		dev_err(dev, "Unable to get battery info: %d\n", ret);
+		return ret;
+	}
+	if (priv->info->voltage_min_design_uv < 0) {
+		dev_err(dev, "Unable to get voltage min design\n");
+		return priv->info->voltage_min_design_uv;
+	}
+	if (priv->info->voltage_max_design_uv < 0) {
+		dev_err(dev, "Unable to get voltage max design\n");
+		return priv->info->voltage_max_design_uv;
+	}
+
+	return 0;
+}
+
+static struct platform_driver nanopi_adc_power_driver = {
+	.driver = {
+		.name = "nanopi-adc-power",
+		.of_match_table = of_match_ptr(nanopi_adc_power_of_match),
+	},
+	.probe = nanopi_adc_power_probe,
+};
+module_platform_driver(nanopi_adc_power_driver);
+
+MODULE_ALIAS("platform:nanopi-adc-power");
+MODULE_AUTHOR("support@friendlyarm.com");
+MODULE_DESCRIPTION("Simple ADC power supply driver for NanoPi 5/6 series");
+MODULE_LICENSE("GPL");


### PR DESCRIPTION
Add ADC voltage driver for NanoPi 5/6 series in order to show the voltage value on `sensors`

Tested on NanoPi M6