### PR TITLE
enable ap6275s bleutooth on armsom sige1 and sige3

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3528-armsom-sige1.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3528-armsom-sige1.dts
@@ -257,19 +257,6 @@
 		reset-gpios = <&gpio1 RK_PA6 GPIO_ACTIVE_LOW>;
 	};
 
-	wireless_bluetooth: wireless-bluetooth {
-		compatible = "bluetooth-platdata";
-		//wifi-bt-power-toggle;
-		uart_rts_gpios = <&gpio1 RK_PB2 GPIO_ACTIVE_LOW>;
-		pinctrl-names = "default", "rts_gpio";
-		pinctrl-0 = <&uart2m1_rtsn>;
-		pinctrl-1 = <&uart2m1_rts_gpio>;
-		BT,power_gpio = <&gpio1 RK_PC1 GPIO_ACTIVE_HIGH>;
-		//BT,reset_gpio    = <&gpio3 RK_PC2 GPIO_ACTIVE_HIGH>;
-		//BT,wake_host_irq = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
-		status = "okay";
-	};
-
 	wireless_wlan: wireless-wlan {
 		compatible = "wlan-platdata";
 		rockchip,grf = <&grf>;
@@ -497,7 +484,18 @@
 &uart2 {
 	status = "okay";
 	pinctrl-names = "default";
-	pinctrl-0 = <&uart2m1_xfer &uart2m1_ctsn>;
+	pinctrl-0 = <&uart2m1_xfer &uart2m1_ctsn &uart2m1_rtsn>;
+	uart-has-rtscts;
+	bluetooth {
+		compatible = "brcm,bcm43438-bt";
+		device-wakeup-gpios = <&gpio3 RK_PC3 0>;
+		host-wakeup-gpios = <&gpio1 RK_PC2 0>;
+		shutdown-gpios = <&gpio1 RK_PC1 0>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&bt_host_wake &bt_wake &bt_enable>;
+		vbat-supply = <&vcc_3v3_s3>;
+		vddio-supply = <&vdd_1v8_s3>;
+	};
 };
 
 &gmac1 {
@@ -560,6 +558,20 @@
 
 
 &pinctrl {
+	bt {
+		bt_enable: bt-enable {
+			rockchip,pins = <1 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		bt_host_wake: bt-host-wake {
+			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_down>;
+		};
+
+		bt_wake: bt-wake {
+			rockchip,pins = <3 RK_PC3 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
 	sdio-pwrseq {
 		wifi_enable_h: wifi-enable-h {
 			rockchip,pins = <1 RK_PA6 RK_FUNC_GPIO &pcfg_pull_none>;
@@ -572,16 +584,12 @@
 		};
 	};
 
-	wireless-bluetooth {
-		uart2m1_rts_gpio: uart2m1-rts-gpio {
-			rockchip,pins = <1 RK_PB2 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-	};
 	hym8563 {
 		hym8563_int: hym8563-int {
 			rockchip,pins = <4 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
+
 	usb {
 		usb_host1_pwren: usb-host1-pwren {
 			rockchip,pins = <4 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;

--- a/arch/arm64/boot/dts/rockchip/rk3568-armsom-sige3.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-armsom-sige3.dts
@@ -246,18 +246,6 @@
 		pinctrl-0 = <&vcc5v0_otg_en>;
 	};
 
-	wireless_bluetooth: wireless-bluetooth {
-		compatible = "bluetooth-platdata";
-		//wifi-bt-power-toggle;
-		uart_rts_gpios = <&gpio2 RK_PB5 GPIO_ACTIVE_LOW>;
-		pinctrl-names = "default", "rts_gpio";
-		pinctrl-0 = <&uart1m0_rtsn>;
-		pinctrl-1 = <&uart1m0_rts_gpio>;
-		BT,power_gpio = <&gpio2 RK_PB7 GPIO_ACTIVE_HIGH>;
-		//BT,reset_gpio    = <&gpio3 RK_PC2 GPIO_ACTIVE_HIGH>;
-		//BT,wake_host_irq = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
-	};
-
 	wireless_wlan: wireless-wlan {
 		compatible = "wlan-platdata";
 		rockchip,grf = <&grf>;
@@ -759,6 +747,19 @@
 };
 
 &pinctrl {
+	bt {
+		bt_enable: bt-enable {
+			rockchip,pins = <2 RK_PB7 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		bt_host_wake: bt-host-wake {
+			rockchip,pins = <2 RK_PC0 RK_FUNC_GPIO &pcfg_pull_down>;
+		};
+
+		bt_wake: bt-wake {
+			rockchip,pins = <2 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
 
 	headphone {
 		hp_det: hp-det {
@@ -826,12 +827,6 @@
 	wireless-wlan {
 		wifi_host_wake_irq: wifi-host-wake-irq {
 			rockchip,pins = <2 RK_PB2 RK_FUNC_GPIO &pcfg_pull_down>;
-		};
-	};
-
-	wireless-bluetooth {
-		uart1m0_rts_gpio: uart1m0-rts-gpio {
-			rockchip,pins = <2 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 };
@@ -1013,6 +1008,18 @@
 	status = "okay";
 	pinctrl-names = "default";
 	pinctrl-0 = <&uart1m0_xfer &uart1m0_ctsn>;
+	pinctrl-0 = <&uart1m0_xfer &uart1m0_ctsn &uart1m0_rtsn>;
+	uart-has-rtscts;
+	bluetooth {
+		compatible = "brcm,bcm43438-bt";
+		device-wakeup-gpios = <&gpio2 RK_PC1 0>;
+		host-wakeup-gpios = <&gpio2 RK_PC0 0>;
+		shutdown-gpios = <&gpio2 RK_PB7 0>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&bt_host_wake &bt_wake &bt_enable>;
+		vbat-supply = <&vcc3v3_sys>;
+		vddio-supply = <&vcc_1v8>;
+	};
 };
 
 &usb2phy0 {

--- a/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
@@ -330,18 +330,6 @@
 		gpio = <&gpio2 RK_PB1 GPIO_ACTIVE_HIGH>;
 	};
 
-	wireless_bluetooth: wireless-bluetooth {
-		compatible = "bluetooth-platdata";
-		//wifi-bt-power-toggle;
-		uart_rts_gpios = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
-		pinctrl-names = "default", "rts_gpio";
-		pinctrl-0 = <&uart4m1_rtsn>;
-		pinctrl-1 = <&uart4m1_rts_gpio>;
-		BT,power_gpio = <&gpio1 RK_PC7 GPIO_ACTIVE_HIGH>;
-		//BT,reset_gpio    = <&gpio3 RK_PC3 GPIO_ACTIVE_HIGH>;
-		//BT,wake_host_irq = <&gpio1 RK_PC2 GPIO_ACTIVE_HIGH>;
-	};
-
 	wireless_wlan: wireless-wlan {
 		compatible = "wlan-platdata";
 		wifi_chip_type = "rtl8852bs";
@@ -841,6 +829,20 @@
 };
 
 &pinctrl {
+	bt {
+		bt_enable: bt-enable {
+			rockchip,pins = <1 RK_PC7 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		bt_host_wake: bt-host-wake {
+			rockchip,pins = <0 RK_PB1 RK_FUNC_GPIO &pcfg_pull_down>;
+		};
+
+		bt_wake: bt-wake {
+			rockchip,pins = <1 RK_PD4 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
 	cam {
 		mipicsi0_pwr: mipicsi0-pwr {
 			rockchip,pins =
@@ -897,12 +899,6 @@
 
 		usbc1_int: usbc1-int {
 			rockchip,pins = <0 RK_PC3 RK_FUNC_GPIO &pcfg_pull_up>;
-		};
-	};
-
-	wireless-bluetooth {
-		uart4m1_rts_gpio: uart4m1-rts-gpio {
-			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 
@@ -1108,7 +1104,18 @@
 &uart4 {
 	status = "okay";
 	pinctrl-names = "default";
-	pinctrl-0 = <&uart4m1_xfer &uart4m1_ctsn>;
+	pinctrl-0 = <&uart4m1_xfer &uart4m1_ctsn &uart4m1_rtsn>;
+	uart-has-rtscts;
+	bluetooth {
+		compatible = "brcm,bcm43438-bt";
+		device-wakeup-gpios = <&gpio1 RK_PD4 0>;
+		host-wakeup-gpios = <&gpio0 RK_PB1 0>;
+		shutdown-gpios = <&gpio1 RK_PC7 0>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&bt_host_wake &bt_wake &bt_enable>;
+		vbat-supply = <&vcc_3v3_s3>;
+		vddio-supply = <&vcc_1v8_s3>;
+	};
 };
 
 &ufs {


### PR DESCRIPTION
Similar with mainline rock3a: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/arch/arm64/boot/dts/rockchip/rk3568-rock-3a.dts?h=v6.11.5&id=8cf890aabd45664b8f27a5581c8d2a51a8ce2e17
Test with armsom sige1 and sige3.