### PR TITLE
introcude devicetree property rockchip,default-link-up to fix rtl8125 on opi5plus

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
@@ -857,12 +857,14 @@
 //phy2
 &pcie2x1l1 {
     reset-gpios = <&gpio3 RK_PB3 GPIO_ACTIVE_HIGH>;
+    rockchip,default-link-up;
     status = "okay";
 };
 
 //phy0
 &pcie2x1l2 {
     reset-gpios = <&gpio4 RK_PA2 GPIO_ACTIVE_HIGH>;
+    rockchip,default-link-up;
     status = "okay";
 };
 

--- a/drivers/pci/controller/dwc/pcie-dw-rockchip.c
+++ b/drivers/pci/controller/dwc/pcie-dw-rockchip.c
@@ -830,6 +830,10 @@ static const struct dw_pcie_ops dw_pcie_ops = {
 	.link_up = rk_pcie_link_up,
 };
 
+static const struct dw_pcie_ops dw_pcie_ops_default_link_up = {
+	.start_link = rk_pcie_establish_link,
+};
+
 static void rk_pcie_fast_link_setup(struct rk_pcie *rk_pcie)
 {
 	u32 val;
@@ -1153,7 +1157,12 @@ static int rk_pcie_really_probe(void *p)
 	}
 
 	pci->dev = dev;
-	pci->ops = &dw_pcie_ops;
+	if (device_property_read_bool(dev, "rockchip,default-link-up"))
+	{
+		dev_info(dev, "using pcie default link_up because of rockchip,default-link-up\n");
+		pci->ops = &dw_pcie_ops_default_link_up;
+	} else
+		pci->ops = &dw_pcie_ops;
 
 	if (data)
 		rk_pcie->msi_vector_num = data->msi_vector_num;

--- a/drivers/pci/controller/dwc/pcie-dw-rockchip.c
+++ b/drivers/pci/controller/dwc/pcie-dw-rockchip.c
@@ -280,7 +280,8 @@ static int rk_pcie_link_up(struct dw_pcie *pci)
 	u32 val;
 
 	val = rk_pcie_readl_apb(rk_pcie, PCIE_CLIENT_LTSSM_STATUS);
-	if ((val & (RDLH_LINKUP | SMLH_LINKUP)) == 0x30000)
+	if ((val & (RDLH_LINKUP | SMLH_LINKUP)) == 0x30000 &&
+	    (val & GENMASK(5, 0)) == 0x11)
 		return 1;
 
 	return 0;


### PR DESCRIPTION
Fixes #282 
First sync `rk_pcie_link_up` with mainline to fix some nvme devices not detected issue.
Second introcude devicetree property `rockchip,default-link-up` for opi5plus.
Tested on rock5b and with/without the property rtl8125 is always detected.