### PR TITLE
fix: export memblock_free

### DIFF
--- a/mm/memblock.c
+++ b/mm/memblock.c
@@ -875,6 +875,10 @@ int __init_memblock memblock_phys_free(phys_addr_t base, phys_addr_t size)
 	return memblock_remove_range(&memblock.reserved, base, size);
 }
 
+#ifdef CONFIG_ARCH_KEEP_MEMBLOCK
+EXPORT_SYMBOL_GPL(memblock_free);
+#endif
+
 int __init_memblock memblock_reserve(phys_addr_t base, phys_addr_t size)
 {
 	phys_addr_t end = base + size - 1;


### PR DESCRIPTION
This is required for drivers/gpu/drm/rockchip/rockchip_drm_logo.c to compile properly as a module.

Without this patch, build including rockchip-drm fail for me with

ERROR: modpost: "memblock_free" undefined!

cherry-picked from https://android.googlesource.com/kernel/common/+/cd5f5cb9fe677466551e44039b31198e7b0dc812%5E%21/