### PR TITLE
video: rockchip: mpp: rkvdec: suppress cru reset logs

### DIFF
--- a/drivers/video/rockchip/mpp/mpp_rkvdec2.c
+++ b/drivers/video/rockchip/mpp/mpp_rkvdec2.c
@@ -1387,7 +1387,7 @@ int rkvdec2_reset(struct mpp_dev *mpp)
 
 	/* cru reset */
 	if (dec->rst_a && dec->rst_h) {
-		mpp_err("cru reset\n");
+		mpp_debug(DEBUG_RESET, "cru reset\n");
 		mpp_pmu_idle_request(mpp, true);
 		mpp_safe_reset(dec->rst_niu_a);
 		mpp_safe_reset(dec->rst_niu_h);


### PR DESCRIPTION
Suppress this unnecessary log to avoid flooding.

Tested on `Linux rock-5a 6.1.84-vendor-rk35xx #1 SMP Sun Nov 24 10:39:05 UTC 2024 aarch64 GNU/Linux`

```
[  287.968928] rkvdec2_reset:1390: cru reset
[  287.969095] rkvdec2_reset:1390: cru reset
[  307.341233] rkvdec2_reset:1390: cru reset
[  307.341284] rkvdec2_reset:1390: cru reset
[  409.407484] rkvdec2_reset:1390: cru reset
[  409.407659] rkvdec2_reset:1390: cru reset
[  807.117098] rkvdec2_reset:1390: cru reset
[  807.117194] rkvdec2_reset:1390: cru reset
[  936.456230] rkvdec2_reset:1390: cru reset
[  936.456401] rkvdec2_reset:1390: cru reset
...
```

After ba6b241, the cru reset always occurs at the end of
each decoding process. Use `mpp_debug` instead to log it.