### PR TITLE
Several fixes for armsom sige5

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
@@ -10,6 +10,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	armsom-sige5-camera-ov13850-cs0.dtbo \
 	armsom-sige5-camera-ov13850-cs1.dtbo \
 	armsom-sige5-display-10hd.dtbo \
+	armsom-sige5-rtl8852bs-bluetooth.dtbo \
 	armsom-sige7-camera-imx415-4k.dtbo \
 	armsom-sige7-camera-ov13850-csi0.dtbo \
 	armsom-sige7-camera-ov13850-csi1.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlay/armsom-sige5-rtl8852bs-bluetooth.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/armsom-sige5-rtl8852bs-bluetooth.dts
@@ -1,0 +1,10 @@
+/dts-v1/;
+/plugin/;
+/ {
+	fragment@0 {
+		target = <&bluetooth>;
+		__overlay__ {
+			compatible = "realtek,rtl8723ds-bt";
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
@@ -7,7 +7,6 @@
 /dts-v1/;
 
 #include <dt-bindings/display/rockchip_vop.h>
-#include <dt-bindings/display/drm_mipi_dsi.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/leds/common.h>
 #include <dt-bindings/pinctrl/rockchip.h>
@@ -47,47 +46,6 @@
 				sound-dai = <&es8388>;
 			};
 		};
-	};
-
-	dsi1_backlight: dsi1-backlight {
-		status = "okay";
-		compatible = "pwm-backlight";
-		pwms = <&pwm1_6ch_1 0 25000 0>;
-		brightness-levels = <
-			  0  20  20  21  21  22  22  23
-			 23  24  24  25  25  26  26  27
-			 27  28  28  29  29  30  30  31
-			 31  32  32  33  33  34  34  35
-			 35  36  36  37  37  38  38  39
-			 40  41  42  43  44  45  46  47
-			 48  49  50  51  52  53  54  55
-			 56  57  58  59  60  61  62  63
-			 64  65  66  67  68  69  70  71
-			 72  73  74  75  76  77  78  79
-			 80  81  82  83  84  85  86  87
-			 88  89  90  91  92  93  94  95
-			 96  97  98  99 100 101 102 103
-			104 105 106 107 108 109 110 111
-			112 113 114 115 116 117 118 119
-			120 121 122 123 124 125 126 127
-			128 129 130 131 132 133 134 135
-			136 137 138 139 140 141 142 143
-			144 145 146 147 148 149 150 151
-			152 153 154 155 156 157 158 159
-			160 161 162 163 164 165 166 167
-			168 169 170 171 172 173 174 175
-			176 177 178 179 180 181 182 183
-			184 185 186 187 188 189 190 191
-			192 193 194 195 196 197 198 199
-			200 201 202 203 204 205 206 207
-			208 209 210 211 212 213 214 215
-			216 217 218 219 220 221 222 223
-			224 225 226 227 228 229 230 231
-			232 233 234 235 236 237 238 239
-			240 241 242 243 244 245 246 247
-			248 249 250 251 252 253 254 255
-		>;
-		default-brightness-level = <200>;
 	};
 
 	fan: pwm-fan {
@@ -281,28 +239,6 @@
 		pinctrl-0 = <&usb_otg0_pwren>;
 	};
 
-	vcc_lcd_mipi1: vcc-lcd-mipi1 { 
-		status = "okay";
-		compatible = "regulator-fixed";
-		regulator-name = "vcc_lcd_mipi1";
-		gpio = <&gpio1 RK_PD5 GPIO_ACTIVE_HIGH>;
-		enable-active-high;
-		regulator-boot-on;
-		regulator-state-mem {
-			regulator-off-in-suspend;
-		};
-	};
-
-	vcc3v3_bl_n: vcc3v3-bl-n {
-		compatible = "regulator-fixed";
-		regulator-name = "vcc3v3_bl_n";
-		regulator-boot-on;
-		enable-active-high;
-		pinctrl-names = "default";
-		pinctrl-0 = <&dsi1_backlight_en>;
-		gpio = <&gpio2 RK_PB1 GPIO_ACTIVE_HIGH>;
-	};
-
 	wireless_wlan: wireless-wlan {
 		compatible = "wlan-platdata";
 		wifi_chip_type = "rtl8852bs";
@@ -424,209 +360,9 @@
 	status = "okay";
 };
 
-&dsi {
-	status = "okay";
-	rockchip,lane-rate = <1000>;
-	dsi_panel: panel@0 {
-		status = "okay";
-		compatible = "simple-panel-dsi";
-		reg = <0>;
-		power-supply = <&vcc_lcd_mipi1>; 
-		reset-gpios = <&gpio2 RK_PB3 GPIO_ACTIVE_LOW>;
-		backlight = <&dsi1_backlight>;
-		pinctrl-names = "default";
-		pinctrl-0 = <&dsi1_lcd_rst_gpio>;
-		reset-delay-ms = <10>;
-		enable-delay-ms = <10>;
-		prepare-delay-ms = <10>;
-		unprepare-delay-ms = <10>;
-		disable-delay-ms = <10>;
-		dsi,flags = <(MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
-			MIPI_DSI_MODE_LPM | MIPI_DSI_MODE_NO_EOT_PACKET)>;
-		dsi,format = <MIPI_DSI_FMT_RGB888>;
-		dsi,lanes  = <4>;
-		panel-init-sequence = [
-			15 00 02 B0 01
-			15 00 02 C0 26
-			15 00 02 C1 10
-			15 00 02 C2 0E
-			15 00 02 C3 00
-			15 00 02 C4 00
-			15 00 02 C5 23
-			15 00 02 C6 11
-			15 00 02 C7 22
-			15 00 02 C8 20
-			15 00 02 C9 1E
-			15 00 02 CA 1C
-			15 00 02 CB 0C
-			15 00 02 CC 0A
-			15 00 02 CD 08
-			15 00 02 CE 06
-			15 00 02 CF 18
-			15 00 02 D0 02
-			15 00 02 D1 00
-			15 00 02 D2 00
-			15 00 02 D3 00
-			15 00 02 D4 26
-			15 00 02 D5 0F
-			15 00 02 D6 0D
-			15 00 02 D7 00
-			15 00 02 D8 00
-			15 00 02 D9 23
-			15 00 02 DA 11
-			15 00 02 DB 21
-			15 00 02 DC 1F
-			15 00 02 DD 1D
-			15 00 02 DE 1B
-			15 00 02 DF 0B
-			15 00 02 E0 09
-			15 00 02 E1 07
-			15 00 02 E2 05
-			15 00 02 E3 17
-			15 00 02 E4 01
-			15 00 02 E5 00
-			15 00 02 E6 00
-			15 00 02 E7 00
-			15 00 02 B0 03
-			15 00 02 BE 04
-			15 00 02 B9 40
-			15 00 02 CC 88
-			15 00 02 C8 0C
-			15 00 02 C9 07
-			15 00 02 CD 01
-			15 00 02 CA 40
-			15 00 02 CE 1A
-			15 00 02 CF 60
-			15 00 02 D2 08
-			15 00 02 D3 08
-			15 00 02 DB 01
-			15 00 02 D9 06
-			15 00 02 D4 00
-			15 00 02 D5 01
-			15 00 02 D6 04
-			15 00 02 D7 03
-			15 00 02 C2 00
-			15 00 02 C3 0E
-			15 00 02 C4 00
-			15 00 02 C5 0E
-			15 00 02 DD 00
-			15 00 02 DE 0E
-			15 00 02 E6 00
-			15 00 02 E7 0E
-			15 00 02 C2 00
-			15 00 02 C3 0E
-			15 00 02 C4 00
-			15 00 02 C5 0E
-			15 00 02 DD 00
-			15 00 02 DE 0E
-			15 00 02 E6 00
-			15 00 02 E7 0E
-			15 00 02 B0 06
-			15 00 02 C0 A5
-			15 00 02 D5 1C
-			15 00 02 C0 00
-			15 00 02 B0 00
-			15 00 02 BD 30
-
-			15 00 02 F9 5C
-			15 00 02 C2 14
-			15 00 02 C4 14
-			15 00 02 BF 15
-			15 00 02 C0 0C
-
-
-			15 00 02 B0 00
-			15 00 02 B1 79
-			15 00 02 BA 8F
-
-			05 78 01 11
-			05 78 01 29
-		];
-
-		panel-exit-sequence = [
-			05 32 01 28
-			05 78 01 10
-		];
-
-		disp_timings0: display-timings {
-			native-mode = <&dsi1_timing0>;
-			dsi1_timing0: timing0 {
-				clock-frequency = <160000000>;
-				hactive = <1200>;
-				vactive = <1920>;
-				hfront-porch = <80>;
-				hsync-len = <1>;
-				hback-porch = <60>;
-				vfront-porch = <35>;
-				vsync-len = <1>;
-				vback-porch = <25>;
-				hsync-active = <0>;
-				vsync-active = <0>;
-				de-active = <0>;
-				pixelclk-active = <1>;
-			};
-		};
-		ports {
-			#address-cells = <1>;
-			#size-cells = <0>;
-
-			port@0 {
-				reg = <0>;
-				panel_in_dsi: endpoint {
-					remote-endpoint = <&dsi_out_panel>;
-				};
-			};
-		};
-	};
-	ports {
-		#address-cells = <1>;
-		#size-cells = <0>;
-
-		port@1 {
-			reg = <1>;
-			dsi_out_panel: endpoint {
-				remote-endpoint = <&panel_in_dsi>;
-			};
-		};
-	};
-};
-
-&mipidcphy0 {
-	status = "okay";
-};
-
-&route_dsi {
-	status = "disabled";
-};
-
-&dsi_in_vp1 {
-	status = "okay";
-};
-
-&vp1 {
-	assigned-clocks = <&cru DCLK_VP1_SRC>;
-	assigned-clock-parents = <&cru PLL_VPLL>;
-};
-
 &i2c0 {
 	status = "okay";
 	pinctrl-0 = <&i2c0m1_xfer>;
-	gt9xx: gt9xx@14 {          
-		status = "okay";
-		compatible = "goodix,gt9xx";
-		reg = <0x14>;
-		pinctrl-names = "default";
-		pinctrl-0 = <&gt9xx_gpio>;
-		touch-gpio = <&gpio0 RK_PD1 IRQ_TYPE_LEVEL_HIGH>;
-		reset-gpio = <&gpio0 RK_PD3 GPIO_ACTIVE_HIGH>;
-		max-x = <1200>;
-		max-y = <1920>;
-		tp-size = <89>;  
-		tp-supply = <&vcc_lcd_mipi1>;
-
-		configfile-num = <1>;   
-	};
-
 	usbc1: fusb302@22 {
 		compatible = "fcs,fusb302";
 		reg = <0x22>;
@@ -864,31 +600,6 @@
 			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
-
-	dsi1-lcd {
-		dsi1_lcd_rst_gpio: dsi1-lcd-rst-gpio {
-			rockchip,pins =
-				<2 RK_PB3 RK_FUNC_GPIO &pcfg_pull_up>;
-		};
-
-		dsi1_backlight_en: dsi1-backlight-en {
-			rockchip,pins =
-				<2 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
-		};
-	};
-
-	gt9xx {
-		gt9xx_gpio: gt9xx-gpio {
-			rockchip,pins =
-				<0 RK_PD1 RK_FUNC_GPIO &pcfg_pull_none>,
-				<0 RK_PD3 RK_FUNC_GPIO &pcfg_pull_up>;
-		};
-	};
-};
-
-&pwm1_6ch_1 {
-	status = "okay";
-	pinctrl-0 = <&pwm1m0_ch1>;
 };
 
 &pwm2_8ch_7 {

--- a/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
@@ -1059,7 +1059,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&uart4m1_xfer &uart4m1_ctsn &uart4m1_rtsn>;
 	uart-has-rtscts;
-	bluetooth {
+	bluetooth:bluetooth-serial {
 		compatible = "brcm,bcm43438-bt";
 		device-wakeup-gpios = <&gpio1 RK_PD4 0>;
 		host-wakeup-gpios = <&gpio0 RK_PB1 0>;

--- a/drivers/bluetooth/btrtl.c
+++ b/drivers/bluetooth/btrtl.c
@@ -231,6 +231,14 @@ static const struct id_table ic_id_table[] = {
 	  .fw_name  = "rtl_bt/rtl8852au_fw.bin",
 	  .cfg_name = "rtl_bt/rtl8852au_config" },
 
+	/* 8852B with UART interface */
+	{ IC_INFO(RTL_ROM_LMP_8852A, 0xb, 0xb, HCI_UART),
+	  .config_needed = true,
+	  .has_rom_version = true,
+	  .has_msft_ext = true,
+	  .fw_name  = "rtl_bt/rtl8852bs_fw.bin",
+	  .cfg_name = "rtl_bt/rtl8852bs_config" },
+
 	/* 8852B */
 	{ IC_INFO(RTL_ROM_LMP_8852A, 0xb, 0xb, HCI_USB),
 	  .config_needed = false,
@@ -1084,6 +1092,8 @@ MODULE_FIRMWARE("rtl_bt/rtl8822b_fw.bin");
 MODULE_FIRMWARE("rtl_bt/rtl8822b_config.bin");
 MODULE_FIRMWARE("rtl_bt/rtl8852au_fw.bin");
 MODULE_FIRMWARE("rtl_bt/rtl8852au_config.bin");
+MODULE_FIRMWARE("rtl_bt/rtl8852bs_fw.bin");
+MODULE_FIRMWARE("rtl_bt/rtl8852bs_config.bin");
 MODULE_FIRMWARE("rtl_bt/rtl8852bu_fw.bin");
 MODULE_FIRMWARE("rtl_bt/rtl8852bu_config.bin");
 MODULE_FIRMWARE("rtl_bt/rtl8852cu_fw.bin");


### PR DESCRIPTION
- We have dsi panel node in devicetree of armsom sige5 when we don't have dt overlay support. Now we have supported dsi display by dt overlay: https://github.com/armbian/linux-rockchip/blob/rk-6.1-rkr4.1/arch/arm64/boot/dts/rockchip/overlay/armsom-sige5-display-10hd.dts, so delete the nodes from main devicetree
- Some early version of armsom sige5 boards have rtl8852bs wifi/bt module. And the bluetooth need somw patches to work: One patch to bluetooth driver to support rtl8852bs, and one dts overlay to change the bluetooth compatibale string in devicetree.