### PR TITLE
soc: rockchip: Kconfig: disable ROCKCHIP_THUNDER_BOOT* by default

### DIFF
--- a/drivers/soc/rockchip/Kconfig
+++ b/drivers/soc/rockchip/Kconfig
@@ -276,6 +276,7 @@ endif
 
 config ROCKCHIP_THUNDER_BOOT
 	bool "Rockchip Thunder Boot support"
+	default n
 	depends on NO_GKI
 	select ROCKCHIP_THUNDER_BOOT_DEFER_FREE_MEMBLOCK if SMP
 	help
@@ -284,6 +285,7 @@ config ROCKCHIP_THUNDER_BOOT
 
 config ROCKCHIP_THUNDER_BOOT_DEFER_FREE_MEMBLOCK
 	bool "Defer free large memblock to Buddy allocator"
+	depends on ROCKCHIP_THUNDER_BOOT
 	depends on SMP
 	depends on NO_GKI
 	help


### PR DESCRIPTION
`ROCKCHIP_THUNDER_BOOT_DEFER_FREE_MEMBLOCK` should depend on `ROCKCHIP_THUNDER_BOOT`, and it
creates an artificial threads-max limit that is not suitable for generic linux.

Disable it by default to avoid it being accidentally enabled.

Related to https://github.com/armbian/linux-rockchip/issues/307