### PR TITLE
module: Fix KCOV-ignored file name

### DIFF
--- a/kernel/module/Makefile
+++ b/kernel/module/Makefile
@@ -5,7 +5,7 @@
 
 # These are called from save_stack_trace() on slub debug path,
 # and produce insane amounts of uninteresting coverage.
-KCOV_INSTRUMENT_module.o := n
+KCOV_INSTRUMENT_main.o := n
 
 obj-y += main.o strict_rwx.o
 obj-$(CONFIG_MODULE_DECOMPRESS) += decompress.o


### PR DESCRIPTION
This is picked from linux-stable to fix dkms module load when BTF is enabled.
More info: https://github.com/armbian/build/pull/7629