### PR TITLE
Add some fixes for friendlyelec nanopi-r6/nanopc-t6 series

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts
@@ -477,7 +477,7 @@
 	vpcie3v3-supply = <&vcc3v3_pcie30>;
 	status = "okay";
 
-	pcie@30 {
+	pcie@0,0 {
 		reg = <0x00300000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;
@@ -493,7 +493,7 @@
 	vpcie3v3-supply = <&vcc_3v3_pcie20>;
 	status = "okay";
 
-	pcie@40 {
+	pcie@0,0 {
 		reg = <0x00400000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
@@ -471,6 +471,8 @@
 };
 
 &pcie3x4 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pcie30x4_clkreqn_m1>;
 	reset-gpios = <&gpio4 RK_PB6 GPIO_ACTIVE_HIGH>;
 	vpcie3v3-supply = <&vcc3v3_pcie30>;
 	status = "okay";
@@ -563,6 +565,10 @@
 
 		pcie_m2_1_pwren: pcie-m21-pwren {
 			rockchip,pins = <4 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		pcie30x4_clkreqn_m1: pcie30x4-clkreqn-m1 {
+			rockchip,pins = <4 RK_PB4 RK_FUNC_GPIO &pcfg_pull_down>;
 		};
 	};
 

--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
@@ -430,7 +430,7 @@
 	vpcie3v3-supply = <&vcc_3v3_pcie20>;
 	status = "okay";
 
-	pcie@20 {
+	pcie@0,0 {
 		reg = <0x00200000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;
@@ -454,7 +454,7 @@
 	vpcie3v3-supply = <&vcc_3v3_pcie20>;
 	status = "okay";
 
-	pcie@40 {
+	pcie@0,0 {
 		reg = <0x00400000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;

--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
@@ -608,7 +608,7 @@
 };
 
 &sdmmc {
-	max-frequency = <150000000>;
+	max-frequency = <200000000>;
 	no-sdio;
 	no-mmc;
 	bus-width = <4>;

--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6s.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6s.dts
@@ -79,7 +79,7 @@
 };
 
 &pcie2x1l1 {
-	pcie@30 {
+	pcie@0,0 {
 		reg = <0x00300000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;
@@ -92,7 +92,7 @@
 };
 
 &pcie2x1l2 {
-	pcie@40 {
+	pcie@0,0 {
 		reg = <0x00400000 0 0 0 0>;
 		#address-cells = <3>;
 		#size-cells = <2>;

--- a/drivers/soc/rockchip/rockchip_system_monitor.c
+++ b/drivers/soc/rockchip/rockchip_system_monitor.c
@@ -1186,6 +1186,11 @@ rockchip_system_monitor_wide_temp_init(struct monitor_dev_info *info)
 		info->is_low_temp = true;
 	}
 
+	if (!system_monitor->tz) {
+		dev_err(info->dev, "thermal zone is NULL\n");
+		return;
+	}
+
 	ret = thermal_zone_get_temp(system_monitor->tz, &temp);
 	if (ret || temp == THERMAL_TEMP_INVALID) {
 		dev_err(info->dev,
@@ -1372,6 +1377,11 @@ rockchip_system_monitor_register(struct device *dev,
 
 	if (!devp)
 		return ERR_PTR(-EINVAL);
+
+	if (!devp->check_rate_volt) {
+		dev_warn(dev, "using default check_rate_volt\n");
+		devp->check_rate_volt = rockchip_monitor_check_rate_volt;
+	}
 
 	info = kzalloc(sizeof(*info), GFP_KERNEL);
 	if (!info)


### PR DESCRIPTION
Sync two changes from [friendlyelec's tree](https://github.com/friendlyarm/kernel-rockchip/commits?author=911gt3):
- soc: rockchip_system_monitor: fix potential NULL ptr deref
- arm64: dts: rockchip: Set pcie30x4_clkreqn_m1 for nanopc-t6

Fix a build warning "PCI unit address format error" introduced in BSP 6.1 kernel:
- arm64: dts: rockchip: fixes warning in pci_device_reg for nanopi-r6 series

The rk3588's sdmmc supports this speed natively, there is no reason to limit it to 150MHz:
- arm64: dts: rockchip: increase sdmmc frequency to 200MHz for nanopi-r6 series

I have been testing the above changes for a year.