### PR TITLE
Add missing VPU nodes and fix a log spamming issue

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-armsom-aim7.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-armsom-aim7.dtsi
@@ -23,6 +23,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-armsom-w3.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-armsom-w3.dts
@@ -312,6 +312,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;
@@ -473,6 +477,10 @@
 };
 
 &vdpu_mmu {
+	status = "okay";
+};
+
+&vepu {
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3588-blade3-v101-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blade3-v101-linux.dts
@@ -246,6 +246,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;
@@ -613,6 +617,10 @@
 };
 
 &vdpu_mmu {
+	status = "okay";
+};
+
+&vepu {
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3588-cyber-aib.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-cyber-aib.dts
@@ -258,6 +258,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-firefly-itx-3588j.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-firefly-itx-3588j.dts
@@ -410,6 +410,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &can1 {
 	status = "okay";
 	assigned-clocks = <&cru CLK_CAN1>;
@@ -1366,6 +1370,10 @@
 };
 
 &vdpu_mmu {
+	status = "okay";
+};
+
+&vepu {
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3588-fxblox-rk1.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-fxblox-rk1.dts
@@ -269,6 +269,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-hinlink-h88k.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-hinlink-h88k.dts
@@ -336,6 +336,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &combphy0_ps {
 	status = "okay";
 };
@@ -1069,6 +1073,10 @@
 };
 
 &vdpu_mmu {
+	status = "okay";
+};
+
+&vepu {
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3588-mixtile-core3588e.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-mixtile-core3588e.dts
@@ -239,6 +239,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;
@@ -523,6 +527,10 @@
 };
 
 &vdpu_mmu {
+	status = "okay";
+};
+
+&vepu {
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
@@ -431,7 +431,15 @@
 	};
 };
 
+&av1d {
+	status = "okay";
+};
+
 &av1d_mmu {
+	status = "okay";
+};
+
+&avsd {
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-plus.dts
@@ -377,6 +377,10 @@
 &av1d_mmu {
 	status = "okay";
 };
+
+&avsd {
+	status = "okay";
+};
  
 &can0 {
 	status = "disabled";

--- a/arch/arm64/boot/dts/rockchip/rk3588-radxa-rock-5b+.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-radxa-rock-5b+.dts
@@ -256,6 +256,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5-itx.dts
@@ -308,6 +308,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
@@ -244,6 +244,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588-turing-rk1.dtsi
@@ -209,6 +209,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;

--- a/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-khadas-edge2.dts
@@ -308,6 +308,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &combphy0_ps {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588s-lubancat-4.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-lubancat-4.dts
@@ -393,6 +393,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &spdif_tx2 {
     status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-nanopi-r6-common.dtsi
@@ -685,6 +685,10 @@
 	status = "okay";
 };
 
+&vepu {
+	status = "okay";
+};
+
 &vop {
 	assigned-clocks = <&cru ACLK_VOP>;
 	assigned-clock-rates = <800000000>;

--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5-pro.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5-pro.dts
@@ -294,6 +294,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &gpu {
 	mali-supply = <&vdd_gpu_s0>;
 	mem-supply = <&vdd_gpu_mem_s0>;

--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi-5.dts
@@ -281,6 +281,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &can1 {
 	status = "disabled";
 	pinctrl-names = "default";

--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-cm5.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-cm5.dtsi
@@ -118,6 +118,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;
@@ -383,4 +387,16 @@
 &vdd_0v75_s0 {
 	regulator-min-microvolt = <837500>;
 	regulator-max-microvolt = <837500>;
+};
+
+&vdpu {
+	status = "okay";
+};
+
+&vdpu_mmu {
+	status = "okay";
+};
+
+&vepu {
+	status = "okay";
 };

--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-e52c.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-e52c.dts
@@ -341,6 +341,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &saradc {
 	status = "okay";
 	vref-supply = <&avcc_1v8_s0>;
@@ -416,6 +420,10 @@
 };
 
 &vdpu_mmu {
+	status = "okay";
+};
+
+&vepu {
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-module.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-nx5-module.dtsi
@@ -141,6 +141,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &cpu_l0 {
 	cpu-supply = <&vdd_cpu_lit_s0>;
 	mem-supply = <&vdd_cpu_lit_mem_s0>;
@@ -415,6 +419,18 @@
 		regulator-on-in-suspend;
 		regulator-suspend-microvolt = <850000>;
 	};
+};
+
+&vdpu {
+	status = "okay";
+};
+
+&vdpu_mmu {
+	status = "okay";
+};
+
+&vepu {
+	status = "okay";
 };
 
 &pinctrl {

--- a/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-roc-pc.dts
@@ -297,6 +297,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 /* default use sata3.0 , pcie2.0 optional*/
 &combphy0_ps {
 	status = "okay";
@@ -972,6 +976,10 @@
 };
 
 &vdpu_mmu {
+	status = "okay";
+};
+
+&vepu {
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5a.dts
@@ -177,6 +177,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &i2c0 {
 	status = "okay";
 	pinctrl-names = "default";

--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
@@ -229,6 +229,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 /* CPU */
 
 &cpu_l0 {

--- a/arch/arm64/boot/dts/rockchip/rk3588s-yyt-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-yyt-common.dtsi
@@ -466,6 +466,10 @@
 	status = "okay";
 };
 
+&avsd {
+	status = "okay";
+};
+
 &saradc {
 	status = "okay";
 	vref-supply = <&avcc_1v8_s0>;

--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
+++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
@@ -573,8 +573,8 @@ static unsigned int hdmi_find_n(struct dw_hdmi_qp *hdmi, unsigned long pixel_clk
 	if (n > 0)
 		return n;
 
-	dev_warn(hdmi->dev, "Rate %lu missing; compute N dynamically\n",
-		 pixel_clk);
+	dev_dbg(hdmi->dev, "Rate %lu missing; compute N dynamically\n",
+		pixel_clk);
 
 	return hdmi_compute_n(hdmi, pixel_clk, sample_rate);
 }


### PR DESCRIPTION
- arm64: dts: rockchip: enable av1d/avsd/vdpu/vdpu_mmu/vepu for rk3588
  ```
  // MPP requires them.
  av1d -> av1 decoder
  avsd -> avs/avs2 decoder
  vdpu -> mpeg2/mpeg4/jpeg/vp8 decoder
  vepu -> jpeg/vp8 encoder
  ```

- drivers: drm: dw-hdmi-qp: Stop compute-N spamming kernel logs
  ```
  // Stop the following device warning.
  [24073.665748] dwhdmi-rockchip fde80000.hdmi: Rate 241500000 missing; compute N dynamically
  ...
  ```