### PR TITLE
module, bpf: Store BTF base pointer in struct module

### DIFF
--- a/include/linux/module.h
+++ b/include/linux/module.h
@@ -475,7 +475,9 @@ struct module {
 #endif
 #ifdef CONFIG_DEBUG_INFO_BTF_MODULES
 	unsigned int btf_data_size;
+	unsigned int btf_base_data_size;
 	void *btf_data;
+	void *btf_base_data;
 #endif
 #ifdef CONFIG_JUMP_LABEL
 	struct jump_entry *jump_entries;

--- a/kernel/module/main.c
+++ b/kernel/module/main.c
@@ -2056,6 +2056,8 @@ static int find_module_sections(struct module *mod, struct load_info *info)
 #endif
 #ifdef CONFIG_DEBUG_INFO_BTF_MODULES
 	mod->btf_data = any_section_objs(info, ".BTF", 1, &mod->btf_data_size);
+	mod->btf_base_data = any_section_objs(info, ".BTF.base", 1,
+					      &mod->btf_base_data_size);
 #endif
 #ifdef CONFIG_JUMP_LABEL
 	mod->jump_entries = section_objs(info, "__jump_table",
@@ -2516,8 +2518,9 @@ static noinline int do_init_module(struct module *mod)
 	mod->init_layout.ro_after_init_size = 0;
 	mod->init_layout.text_size = 0;
 #ifdef CONFIG_DEBUG_INFO_BTF_MODULES
-	/* .BTF is not SHF_ALLOC and will get removed, so sanitize pointer */
+	/* .BTF is not SHF_ALLOC and will get removed, so sanitize pointers */
 	mod->btf_data = NULL;
+	mod->btf_base_data = NULL;
 #endif
 	/*
 	 * We want to free module_init, but be aware that kallsyms may be


### PR DESCRIPTION
We have backported https://github.com/torvalds/linux/commit/f34d086fb7102fec895fd58b9e816b981b284c17 to fix dkms module load issue for rkr4.1 kernel, but after updating to rkr5 it issue comes again.

I have to backport this commit when I'm investigating the issue: https://github.com/armbian/build/pull/7629#issuecomment-2590320694.