### PR TITLE
Add rk3568-npu-enable.dts

### DIFF
--- a/arch/arm64/boot/dts/rockchip/Makefile
+++ b/arch/arm64/boot/dts/rockchip/Makefile
@@ -52,6 +52,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3358m-vehicle-v10.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-evb-act8846.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-geekbox.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-lion-haikou.dtb
+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3568-npu-enable.dts
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-orion-r68-meta.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-px5-evb.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3368-r88.dtb

--- a/arch/arm64/boot/dts/rockchip/rk3568-npu-enable.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-npu-enable.dts
@@ -1,0 +1,37 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable NPU";
+		compatible = "radxa,rock-3a", "radxa,rock-3b", "radxa,rock-3c", "radxa,cm3-io", "radxa,cm3-rpi-cm4-io", "radxa,e23", "radxa,e25", "radxa,cm3i-io", "radxa,zero3";
+		category = "misc";
+		exclusive = "rknpu";
+		description = "Enable NPU.";
+	};
+};
+
+&bus_npu {
+	bus-supply = <&vdd_logic>;
+	pvtm-supply = <&vdd_cpu>;
+	status = "okay";
+};
+
+&rknpu {
+	memory-region = <&rknpu_reserved>;
+	status = "okay";
+};
+
+&rknpu_mmu {
+	status = "okay";
+};
+
+&reserved_memory {
+	rknpu_reserved: rknpu {
+		compatible = "shared-dma-pool";
+		inactive;
+		reusable;
+		size = <0x0 0x8000000>;
+		alignment = <0x0 0x1000>;
+	};
+};


### PR DESCRIPTION
Add rk3568-npu-enable.dts device tree overlay to enable NPU on RK3566 devices like Radxa Zero 3

- Add rk3568-npu-enable.dts to arch/arm64/boot/dts/rockchip/overlays/
- Update makefile to add overlay