### PR TITLE
arm64: dts: Fixed the problem of WiFi not being recognized and increa…

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/armsom-sige5-display-10hd.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/armsom-sige5-display-10hd.dts
@@ -298,7 +298,7 @@
 				reset-gpio = <&gpio0 RK_PD3 GPIO_ACTIVE_HIGH>;
 				max-x = <1200>;
 				max-y = <1920>;
-				tp-size = <89>;
+				tp-size = <9271>;
 				tp-supply = <&vcc_lcd_mipi1>;
 
 				configfile-num = <1>;

--- a/arch/arm64/boot/dts/rockchip/overlay/armsom-sige7-display-10hd.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/armsom-sige7-display-10hd.dts
@@ -313,7 +313,7 @@
 				reset-gpio = <&gpio0 RK_PC6 GPIO_ACTIVE_HIGH>;
 				max-x = <1200>;
 				max-y = <1920>;
-				tp-size = <89>;
+				tp-size = <9271>;
 				tp-supply = <&vcc_lcd_mipi1>;
 
 				configfile-num = <1>;  

--- a/arch/arm64/boot/dts/rockchip/overlay/armsom-w3-display-10hd.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/armsom-w3-display-10hd.dts
@@ -313,7 +313,7 @@
 				reset-gpio = <&gpio0 RK_PC6 GPIO_ACTIVE_HIGH>;
 				max-x = <1200>;
 				max-y = <1920>;
-				tp-size = <89>;
+				tp-size = <9271>;
 				tp-supply = <&vcc_lcd_mipi1>;
 
 				configfile-num = <1>;  

--- a/arch/arm64/boot/dts/rockchip/rk3576-armsom-cm5.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3576-armsom-cm5.dtsi
@@ -131,6 +131,36 @@
 			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_up>;
 		};
 	};
+
+	// sdio wifi occasionally fails to recognize, increase the drive current strength to level 5
+	sdmmc1 {
+		/omit-if-no-ref/
+		sdmmc1m0_bus4: sdmmc1m0-bus4 {
+			rockchip,pins =
+				/* sdmmc1_d0_m0 */
+				<1 RK_PB4 2 &pcfg_pull_up_drv_level_5>,
+				/* sdmmc1_d1_m0 */
+				<1 RK_PB5 2 &pcfg_pull_up_drv_level_5>,
+				/* sdmmc1_d2_m0 */
+				<1 RK_PB6 2 &pcfg_pull_up_drv_level_5>,
+				/* sdmmc1_d3_m0 */
+				<1 RK_PB7 2 &pcfg_pull_up_drv_level_5>;
+		};
+
+		/omit-if-no-ref/
+		sdmmc1m0_clk: sdmmc1m0-clk {
+			rockchip,pins =
+				/* sdmmc1_clk_m0 */
+				<1 RK_PC1 2 &pcfg_pull_up_drv_level_5>;
+		};
+
+		/omit-if-no-ref/
+		sdmmc1m0_cmd: sdmmc1m0-cmd {
+			rockchip,pins =
+				/* sdmmc1_cmd_m0 */
+				<1 RK_PC0 2 &pcfg_pull_up_drv_level_5>;
+		};
+	};
 };
 
 &rga2_core0 {

--- a/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
@@ -600,6 +600,36 @@
 			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
+	
+	// sdio wifi occasionally fails to recognize, increase the drive current strength to level 5
+	sdmmc1 {
+		/omit-if-no-ref/
+		sdmmc1m0_bus4: sdmmc1m0-bus4 {
+			rockchip,pins =
+				/* sdmmc1_d0_m0 */
+				<1 RK_PB4 2 &pcfg_pull_up_drv_level_5>,
+				/* sdmmc1_d1_m0 */
+				<1 RK_PB5 2 &pcfg_pull_up_drv_level_5>,
+				/* sdmmc1_d2_m0 */
+				<1 RK_PB6 2 &pcfg_pull_up_drv_level_5>,
+				/* sdmmc1_d3_m0 */
+				<1 RK_PB7 2 &pcfg_pull_up_drv_level_5>;
+		};
+
+		/omit-if-no-ref/
+		sdmmc1m0_clk: sdmmc1m0-clk {
+			rockchip,pins =
+				/* sdmmc1_clk_m0 */
+				<1 RK_PC1 2 &pcfg_pull_up_drv_level_5>;
+		};
+
+		/omit-if-no-ref/
+		sdmmc1m0_cmd: sdmmc1m0-cmd {
+			rockchip,pins =
+				/* sdmmc1_cmd_m0 */
+				<1 RK_PC0 2 &pcfg_pull_up_drv_level_5>;
+		};
+	};
 };
 
 &pwm2_8ch_7 {


### PR DESCRIPTION
ArmSoM-sige5 and ArmSoM-cm5 use BW3752-50B1, which is the wifi of sdio interface. Occasionally, sdio cannot be recognized. After increasing the driving current intensity to level 5, the problem is solved successfully.