### PR TITLE
Add NPU to zero3 device tree

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3566-radxa-zero3.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3566-radxa-zero3.dtsi
@@ -453,7 +453,18 @@
 };
 
 &rknpu {
-	rknpu-supply = <&vdd_gpu>;
+	memory-region = <&rknpu_reserved>;
+	status = "okay";
+};
+
+&bus_npu {
+	bus-supply = <&vdd_logic>;
+	pvtm-supply = <&vdd_cpu>;
+	status = "okay";
+};
+
+&rknpu_mmu {
+	status = "okay";
 };
 
 &saradc {
@@ -629,6 +640,13 @@
 		console-size = <0x80000>;
 		ftrace-size = <0x00000>;
 		pmsg-size = <0x50000>;
+	};
+	rknpu_reserved: rknpu {
+		compatible = "shared-dma-pool";
+		inactive;
+		reusable;
+		size = <0x0 0x8000000>;
+		alignment = <0x0 0x1000>;
 	};
 };
 


### PR DESCRIPTION
Sourced from radxa rk3568-npu-enable.dts