### PR TITLE
Make Goodix a module and disable FW update by default

### DIFF
--- a/drivers/input/touchscreen/gtx8/Kconfig
+++ b/drivers/input/touchscreen/gtx8/Kconfig
@@ -2,9 +2,9 @@
 # Goodix touchscreen driver configuration
 #
 menuconfig TOUCHSCREEN_GOODIX_GTX8
-	bool "Goodix GTx8 touchscreen"
+	tristate "Goodix GTx8 touchscreen"
 	depends on I2C
-	default y
+	default m
 	help
 	  Say Y here if you have a Goodix GTx8 touch controller
 	  to your system.
@@ -15,7 +15,7 @@ if TOUCHSCREEN_GOODIX_GTX8
 
 config TOUCHSCREEN_GOODIX_GTX8_UPDATE
 	tristate "Goodix GTx8 firmware update module"
-	default y
+	default n
 	help
 	  Say Y here to enable support for doing firmware update.
 

--- a/drivers/input/touchscreen/gtx8/goodix_ts_core.c
+++ b/drivers/input/touchscreen/gtx8/goodix_ts_core.c
@@ -595,7 +595,6 @@ static ssize_t goodix_ts_irq_info_show(struct device *dev,
 				       char *buf)
 {
 	struct goodix_ts_core *core_data = dev_get_drvdata(dev);
-	struct irq_desc *desc;
 	size_t offset = 0;
 	int r;
 
@@ -607,13 +606,6 @@ static ssize_t goodix_ts_irq_info_show(struct device *dev,
 	r = snprintf(&buf[offset], PAGE_SIZE - offset, "state:%s\n",
 		     atomic_read(&core_data->irq_enabled) ?
 		     "enabled" : "disabled");
-	if (r < 0)
-		return -EINVAL;
-
-	desc = irq_to_desc(core_data->irq);
-	offset += r;
-	r = snprintf(&buf[offset], PAGE_SIZE - offset, "disable-depth:%d\n",
-		     desc->depth);
 	if (r < 0)
 		return -EINVAL;
 


### PR DESCRIPTION
This change fixes the annoying FW update failure message from the kernel, and also makes it possible to store the touch config in `/lib/firmware` instead of bundling it in initramfs, at the sacrifice of some debug output hardly anybody needs at all.