### PR TITLE
RK3588 Overlay: Allow DMC to use LPDDR5-6400

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-dmc-oc-3500mhz.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3588-dmc-oc-3500mhz.dts
@@ -1,0 +1,25 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target = <&dmc_opp_table>;
+		__overlay__ {
+			opp-2750000000 {
+				delete-property;
+			};
+			opp-3500000000 {
+				opp-supported-hw = <0xf9 0xffff>;
+				opp-hz = /bits/ 64 <3500000000>;
+				opp-microvolt = <875000 875000 875000>,
+						<750000 750000 800000>;
+				opp-microvolt-L1 = <850000 850000 875000>,
+						   <750000 750000 800000>;
+				opp-microvolt-L2 = <837500 837500 875000>,
+						   <725000 725000 800000>;
+				opp-microvolt-L3 = <825000 825000 875000>,
+						   <700000 700000 800000>;
+			};
+		};
+	};
+};


### PR DESCRIPTION
# Description

This is related to: https://github.com/hbiyik/rkddr which is a tool that allows to easily modify the DDR TPL for Rockchip SoC's. 

Using this overlay with [rkddr](https://github.com/hbiyik/rkddr) tool from @hbiyik we can make use of **LPDDR5-6400** speeds instead of the LPDDR5-5500 set by Rockchip.

# Testing

Radxa Boards:
- 5T (tested with H58G56AK6B-X069, LPDDR5-6400 module)
- 5B+ (tested with H58GG8AK8Q-X103, LPDDR5X-8533 module limited by RK3588 controller)

## Testing method

- Set DMC governor to performance and confirm checking `cur_freq`

# Results

- For GPU related tasks we see an up to **20% uplift** when using glmark2-wayland with panthor driver on the terrain scene

> [!CAUTION]
> RK3588 is validated for up to LPDDR5-5500 any damage caused to your hardware by choosing to enable this overlay as well as setting rkddr speeds is your own fault.