### PR TITLE
RK3588 Overlay: add dmc-oc-3500mhz overlay to makefile

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
@@ -89,6 +89,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	nanopi-m6-display-dsi0-yx35.dtbo \
 	nanopi-m6-display-dsi1-yx35.dtbo \
 	nanopi-m6-spi-nor-flash.dtbo \
+	rockchip-rk3588-dmc-oc-3500mhz.dtbo \
 	rockchip-rk3588-opp-oc-24ghz.dtbo \
 	rockchip-rk3588-panthor-gpu.dtbo \
 	rk3528-rock-2-enable-pcie.dtbo \


### PR DESCRIPTION
This overlay file was actually excluded from the build process and is therein a regression from https://github.com/armbian/linux-rockchip/pull/352.

Tested and verified on a Rock-5T board with the https://github.com/hbiyik/rkddr tool.