### PR TITLE
add cpu and mem supply to all big cores on rk3582 boards

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-cm5.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-cm5.dtsi
@@ -132,9 +132,21 @@
 	mem-supply = <&vdd_cpu_big0_mem_s0>;
 };
 
+&cpu_b1 {
+	cpu-supply = <&vdd_cpu_big0_s0>;
+	mem-supply = <&vdd_cpu_big0_mem_s0>;
+	#cooling-cells = <2>;
+};
+
 &cpu_b2 {
 	cpu-supply = <&vdd_cpu_big1_s0>;
 	mem-supply = <&vdd_cpu_big1_mem_s0>;
+};
+
+&cpu_b3 {
+	cpu-supply = <&vdd_cpu_big1_s0>;
+	mem-supply = <&vdd_cpu_big1_mem_s0>;
+	#cooling-cells = <2>;
 };
 
 &gpu {

--- a/arch/arm64/boot/dts/rockchip/rk3588s-radxa-e52c.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-radxa-e52c.dts
@@ -182,9 +182,21 @@
 	mem-supply = <&vdd_cpu_big0_mem_s0>;
 };
 
+&cpu_b1 {
+	cpu-supply = <&vdd_cpu_big0_s0>;
+	mem-supply = <&vdd_cpu_big0_mem_s0>;
+	#cooling-cells = <2>;
+};
+
 &cpu_b2 {
 	cpu-supply = <&vdd_cpu_big1_s0>;
 	mem-supply = <&vdd_cpu_big1_mem_s0>;
+};
+
+&cpu_b3 {
+	cpu-supply = <&vdd_cpu_big1_s0>;
+	mem-supply = <&vdd_cpu_big1_mem_s0>;
+	#cooling-cells = <2>;
 };
 
 /* GPU */

--- a/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-rock-5c.dts
@@ -245,9 +245,21 @@
 	mem-supply = <&vdd_cpu_big0_mem_s0>;
 };
 
+&cpu_b1 {
+	cpu-supply = <&vdd_cpu_big0_s0>;
+	mem-supply = <&vdd_cpu_big0_mem_s0>;
+	#cooling-cells = <2>;
+};
+
 &cpu_b2 {
 	cpu-supply = <&vdd_cpu_big1_s0>;
 	mem-supply = <&vdd_cpu_big1_mem_s0>;
+};
+
+&cpu_b3 {
+	cpu-supply = <&vdd_cpu_big1_s0>;
+	mem-supply = <&vdd_cpu_big1_mem_s0>;
+	#cooling-cells = <2>;
 };
 
 /* GPU */


### PR DESCRIPTION
A user has reported that his rock5c lite only runs at minimal cpu freq. His rock5c lite has a broken cpu6, which is disabled by uboot(cpu_b2). Now all rk3588 boards has the cpu-supply defined at cpu_b2, when the node is disabled, the cpu freq driver can't be initialized.

He has confirmed that this issue doesn't happend with mainline kernel because all cpu core nodes has defined cpu-supply in mainline devicetree, so I add cpu-supply and mem-supply to the two rk3582 boards.