### PR TITLE
slow down sdio freq to 100M to armsom rk3576 boards

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3576-armsom-cm5.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3576-armsom-cm5.dtsi
@@ -218,7 +218,7 @@
 };
 
 &sdio {
-	max-frequency = <200000000>;
+	max-frequency = <100000000>;
 	no-sd;
 	no-mmc;
 	bus-width = <4>;

--- a/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
@@ -708,7 +708,7 @@
 };
 
 &sdio {
-	max-frequency = <150000000>;
+	max-frequency = <100000000>;
 	no-sd;
 	no-mmc;
 	bus-width = <4>;


### PR DESCRIPTION
It's reported that the current sdio freq will cause wifi unstable, it's better to slow it down to 100M.