### PR TITLE
Revert "mmc: dw_mmc: Fix IDMAC operation with pages bigger than 4K"

### DIFF
--- a/drivers/mmc/host/dw_mmc.c
+++ b/drivers/mmc/host/dw_mmc.c
@@ -3094,8 +3094,8 @@ static int dw_mci_init_slot(struct dw_mci *host)
 
 		mmc->max_segs = host->ring_size;
 		mmc->max_blk_size = 65535;
-		mmc->max_req_size = DW_MCI_DESC_DATA_LENGTH * host->ring_size;
-		mmc->max_seg_size = mmc->max_req_size;
+		mmc->max_seg_size = 0x1000;
+		mmc->max_req_size = mmc->max_seg_size * host->ring_size;
 		mmc->max_blk_count = mmc->max_req_size / 512;
 	} else if (host->use_dma == TRANS_MODE_EDMAC) {
 		mmc->max_segs = 64;


### PR DESCRIPTION
Fixes an upstream regression in 6.1.115 that caused SD card controller to emit swiotlb warnings and potential kernel booting and data integrity issues:
```
[   31.794471] dwmmc_rockchip fe2c0000.mmc: swiotlb buffer is full (sz: 942080 bytes), total 32768 (slots), used 52 (slots)
[   31.794828] dwmmc_rockchip fe2c0000.mmc: swiotlb buffer is full (sz: 942080 bytes), total 32768 (slots), used 54 (slots)
[   31.812276] dwmmc_rockchip fe2c0000.mmc: swiotlb buffer is full (sz: 1048576 bytes), total 32768 (slots), used 2 (slots)
[   31.813356] dwmmc_rockchip fe2c0000.mmc: swiotlb buffer is full (sz: 1048576 bytes), total 32768 (slots), used 0 (slots)
[   31.813460] dwmmc_rockchip fe2c0000.mmc: swiotlb buffer is full (sz: 1048576 bytes), total 32768 (slots), used 0 (slots)
[   31.833476] dwmmc_rockchip fe2c0000.mmc: swiotlb buffer is full (sz: 1048576 bytes), total 32768 (slots), used 0 (slots)
[   34.864803] swiotlb_tbl_map_single: 80 callbacks suppressed
```

https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-6.1.y&id=8f9416147d7ed414109d3501f1cb3d7a1735b25a
```
commit 1635e407a4a64d08a8517ac59ca14ad4fc785e75 upstream.

The commit 8396c793ffdf ("mmc: dw_mmc: Fix IDMAC operation with pages bigger than 4K") increased the max_req_size, even for 4K pages, causing various issues:
- Panic booting the kernel/rootfs from an SD card on Rockchip RK3566
- Panic booting the kernel/rootfs from an SD card on StarFive JH7100
- "swiotlb buffer is full" and data corruption on StarFive JH7110

At this stage no fix have been found, so it's probably better to just revert the change.

This reverts commit 8396c793ffdf28bb8aee7cfe0891080f8cab7890.

Cc: stable@vger.kernel.org
Cc: Sam Protsenko <semen.protsenko@linaro.org>
Fixes: 8396c793ffdf ("mmc: dw_mmc: Fix IDMAC operation with pages bigger than 4K")
Closes: https://lore.kernel.org/linux-mmc/614692b4-1dbe-31b8-a34d-cb6db1909bb7@w6rz.net/
Closes: https://lore.kernel.org/linux-mmc/CAC8uq=Ppnmv98mpa1CrWLawWoPnu5abtU69v-=G-P7ysATQ2Pw@mail.gmail.com/

Message-ID: <20241110114700.622372-1-aurelien@aurel32.net>
```