### PR TITLE
media: rockchip: hdmirx: change HDMI unplug message to debug

### DIFF
--- a/drivers/media/platform/rockchip/hdmirx/rk_hdmirx.c
+++ b/drivers/media/platform/rockchip/hdmirx/rk_hdmirx.c
@@ -1713,7 +1713,8 @@ static int hdmirx_wait_lock_and_get_timing(struct rk_hdmirx_dev *hdmirx_dev)
 
 		if (!tx_5v_power_present(hdmirx_dev)) {
 			v4l2_ctrl_s_ctrl(hdmirx_dev->content_type, V4L2_DV_IT_CONTENT_TYPE_NO_ITC);
-			v4l2_err(v4l2_dev, "%s HDMI pull out, return!\n", __func__);
+			v4l2_dbg(1, debug, v4l2_dev,
+				 "%s HDMI pull out, return!\n", __func__);
 			return -1;
 		}
 


### PR DESCRIPTION
If HDMI 5V power is missing, set log unplug event
at debug level instead of error level to reduce log spam.

This change was introduced in commit cc4331bada4a ("media: rockchip: hdmirx: silence spam on opi5plus") and accidentally reverted in commit c15bc2efba09 ("add itc type to hdmirx")

Silence log spam error:
`fdee0000.hdmirx-controller: hdmirx_wait_lock_and_get_timing HDMI pull out, return!`

Tested on OPI5 Ultra