### PR TITLE
ARM: dts: nanopc-t6: fix RT5616 headphone jack DAPM pin mismatch

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-nanopc-t6.dts
@@ -54,7 +54,7 @@
 		simple-audio-card,mclk-fs = <256>;
 
 		simple-audio-card,hp-det-gpio = <&gpio1 RK_PC4 GPIO_ACTIVE_LOW>;
-		simple-audio-card,hp-pin-name = "Headphone Jack";
+		simple-audio-card,hp-pin-name = "Headphones";
 
 		simple-audio-card,widgets =
 			"Headphone", "Headphones",


### PR DESCRIPTION
The simple-audio-card hp-pin-name was referencing "Headphone Jack" but the actual widget is defined as "Headphones", causing ALSA to report "ASoC: DAPM unknown pin Headphone Jack" error.

```bash
[  669.506676] asoc-simple-card rt5616-sound: ASoC: DAPM unknown pin Headphone Jack
[  670.776607] asoc-simple-card rt5616-sound: ASoC: DAPM unknown pin Headphone Jack
[  671.490081] asoc-simple-card rt5616-sound: ASoC: DAPM unknown pin Headphone Jack
[  672.133691] asoc-simple-card rt5616-sound: ASoC: DAPM unknown pin Headphone Jack
[  697.178026] asoc-simple-card rt5616-sound: ASoC: DAPM unknown pin Headphone Jack
[  708.538727] asoc-simple-card rt5616-sound: ASoC: DAPM unknown pin Headphone Jack
[  709.728660] asoc-simple-card rt5616-sound: ASoC: DAPM unknown pin Headphone Jack

```