### PR TITLE
arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts: leds fix

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3576-armsom-sige5.dts
@@ -74,8 +74,17 @@
 	leds: leds {
 		compatible = "gpio-leds";
 		work_led: work {
-			gpios = <&gpio0 RK_PB4 GPIO_ACTIVE_HIGH>;
+			label = "red";
+			gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "default-off";
+			default-state = "off";
+		};
+
+		active_led: active {
+			label = "green";
+			gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "heartbeat";
+			default-state = "on";
 		};
 	};
 


### PR DESCRIPTION
The Sige5 has two user light LEDs: a green light and a red light.

The green user light flashes by default to indicate normal system operation.

The red user light is off by default and can be controlled by the user.