### PR TITLE
arch: arm: dts: rename rk3506-armsom-forge1.dts to rk3506b-armsom-forge1.dts

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -1223,7 +1223,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
 	rk3308hs-voice-module-board-v10-aarch32.dtb \
 	rk3502g-evb1-v10.dtb \
 	rk3503g-evb1-v10.dtb \
-	rk3506-armsom-forge1.dtb \
+	rk3506b-armsom-forge1.dtb \
 	rk3506b-evb1-v10.dtb \
 	rk3506b-test2-v10.dtb \
 	rk3506b-luckfox-lyra-zero-w-sd.dtb \

--- a/arch/arm/boot/dts/rk3506b-armsom-forge1.dts
+++ b/arch/arm/boot/dts/rk3506b-armsom-forge1.dts
@@ -9,7 +9,7 @@
 #include <dt-bindings/suspend/rockchip-rk3506.h>
 #include <dt-bindings/input/rk-input.h>
 #include "rk3506.dtsi"
-#include "rk3506-armsom-forge1-display-8hd.dtsi"
+#include "rk3506b-armsom-forge1-display-8hd.dtsi"
 
 / {
 	model = "Rockchip RK3506J(BGA) ArmSoM Forge1";


### PR DESCRIPTION
ArmSoM Forge1 is using rk3506j, which should be rk3506b series.
Up coming mainline u-boot is using rk3506b-armsom-forge1 as devictree name: https://source.denx.de/u-boot/contributors/kwiboo/u-boot/-/commit/f544cccd624c8d6126e2bf61cb22b78805754368.
To make armbian compatiable with future mainline kernel, we should rename the dtb name.