### PR TITLE
arch: arm: dts: Luckfox Pico Pro/Max (RV1106)

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -1165,6 +1165,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
 	rv1106g-evb2-v12-nofastae-spi-nor.dtb \
 	rv1106g-evb2-v12-spi-nand-tb.dtb \
 	rv1106g-evb2-v12-wakeup.dtb \
+	rv1106g-luckfox-pico-pro-max.dtb \
 	rv1106g-smart-door-lock-rmsl-v10.dtb \
 	rv1106g-smart-door-lock-rmsl-v12.dtb \
 	rv1106g-uvc-demo-v10.dtb \

--- a/arch/arm/boot/dts/rv1106-luckfox-pico-pro-max-ipc.dtsi
+++ b/arch/arm/boot/dts/rv1106-luckfox-pico-pro-max-ipc.dtsi
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2022 Rockchip Electronics Co., Ltd.
+ */
+#include "rv1106-amp.dtsi"
+
+/ {
+	acodec_sound: acodec-sound {
+		compatible = "simple-audio-card";
+		simple-audio-card,name = "rv-acodec";
+		simple-audio-card,format = "i2s";
+		simple-audio-card,mclk-fs = <256>;
+		simple-audio-card,cpu {
+			sound-dai = <&i2s0_8ch>;
+		};
+		simple-audio-card,codec {
+			sound-dai = <&acodec>;
+		};
+	};
+
+	vcc_1v8: vcc-1v8 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_1v8";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+	};
+
+	vcc_3v3: vcc-3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_3v3";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+	};
+
+	vdd_arm: vdd-arm {
+		compatible = "regulator-fixed";
+		regulator-name = "vdd_arm";
+		regulator-min-microvolt = <800000>;
+		regulator-max-microvolt = <1000000>;
+		regulator-init-microvolt = <900000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+	leds: leds {
+		compatible = "gpio-leds";
+		work_led: work{
+			gpios = <&gpio3 RK_PC6 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "activity";
+			default-state = "on";
+		};	
+	};
+
+	// DHT11
+	dht11_sensor {
+		compatible = "dht11";
+		pinctrl-names = "default";
+		pinctrl-0 = <&gpio1_pc7>;
+
+		dht11@1 {
+			gpios = <&gpio1 RK_PC7 GPIO_ACTIVE_HIGH>;
+			label = "dht11";
+			linux,default-trigger = "humidity";
+		};
+	};
+
+};
+
+/***************************** AUDIO ********************************/
+&i2s0_8ch {
+	#sound-dai-cells = <0>;
+	status = "okay";
+};
+
+&acodec {
+	#sound-dai-cells = <0>;
+	pa-ctl-gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+};
+/***************************** CPU ********************************/
+&cpu0 {
+	cpu-supply = <&vdd_arm>;
+};
+
+/***************************** ADC ********************************/
+&saradc {
+	status = "okay";
+	vref-supply = <&vcc_1v8>;
+};
+
+&tsadc {
+	status = "okay";
+};
+
+/***************************** CSI ********************************/
+&csi2_dphy_hw {
+	status = "okay";
+};
+
+&csi2_dphy0 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			csi_dphy_input0: endpoint@0 {
+				reg = <0>;
+				remote-endpoint = <&sc3336_out>;
+				data-lanes = <1 2>;
+			};
+
+			csi_dphy_input1: endpoint@1 {
+				reg = <1>;
+				remote-endpoint = <&mis5001_out>;
+				data-lanes = <1 2>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			csi_dphy_output: endpoint@0 {
+				reg = <0>;
+				remote-endpoint = <&mipi_csi2_input>;
+			};
+		};
+	};
+};
+
+&i2c4 {
+	status = "okay";
+	clock-frequency = <400000>;
+
+	sc3336: sc3336@30 {
+		compatible = "smartsens,sc3336";
+		status = "okay";
+		reg = <0x30>;
+		clocks = <&cru MCLK_REF_MIPI0>;
+		clock-names = "xvclk";
+		pwdn-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&mipi_refclk_out0>;
+		rockchip,camera-module-index = <0>;
+		rockchip,camera-module-facing = "back";
+		rockchip,camera-module-name = "CMK-OT2119-PC1";
+		rockchip,camera-module-lens-name = "30IRC-F16";
+		port {
+			sc3336_out: endpoint {
+				remote-endpoint = <&csi_dphy_input0>;
+				data-lanes = <1 2>;
+			};
+		};
+	};
+
+	mis5001: mis5001@31 {
+		compatible = "imagedesign,mis5001";
+		status = "okay";
+		reg = <0x31>;
+		clocks = <&cru MCLK_REF_MIPI0>;
+		clock-names = "xvclk";
+		reset-gpios = <&gpio3 RK_PC5 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&mipi_refclk_out0>;
+		rockchip,camera-module-index = <0>;
+		rockchip,camera-module-facing = "back";
+		rockchip,camera-module-name = "CMK-OT2115-PC1";
+		rockchip,camera-module-lens-name = "30IRC-F16";
+		port {
+			mis5001_out: endpoint {
+				remote-endpoint = <&csi_dphy_input1>;
+				data-lanes = <1 2>;
+			};
+		};
+	};
+};
+
+&mipi0_csi2 {
+	status = "okay";
+
+	ports {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		port@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mipi_csi2_input: endpoint@1 {
+				reg = <1>;
+				remote-endpoint = <&csi_dphy_output>;
+			};
+		};
+
+		port@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			mipi_csi2_output: endpoint@0 {
+				reg = <0>;
+				remote-endpoint = <&cif_mipi_in>;
+			};
+		};
+	};
+};
+
+&rkcif {
+	status = "okay";
+};
+
+&rkcif_mipi_lvds {
+	status = "okay";
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&mipi_pins>;
+	port {
+		/* MIPI CSI-2 endpoint */
+		cif_mipi_in: endpoint {
+			remote-endpoint = <&mipi_csi2_output>;
+		};
+	};
+};
+
+&rkcif_mipi_lvds_sditf {
+	status = "okay";
+
+	port {
+		/* MIPI CSI-2 endpoint */
+		mipi_lvds_sditf: endpoint {
+			remote-endpoint = <&isp_in>;
+		};
+	};
+};
+
+&rkisp {
+	status = "okay";
+};
+
+&rkisp_vir0 {
+	status = "okay";
+
+	port@0 {
+		isp_in: endpoint {
+			remote-endpoint = <&mipi_lvds_sditf>;
+		};
+	};
+};
+
+
+/*****************************PINCTRL********************************/
+// SPI
+&spi0 {
+	pinctrl-0 = <&spi0m0_clk &spi0m0_miso &spi0m0_mosi &spi0m0_cs0>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	spidev@0 {
+	compatible = "rockchip,spidev";
+		spi-max-frequency = <50000000>;
+		reg = <0>;
+	};
+
+	fbtft@0 {
+		compatible = "sitronix,st7789v";
+		reg = <0>;
+		spi-max-frequency = <20000000>;
+		fps = <30>;
+		buswidth = <8>;
+		debug = <0x7>;
+		led-gpios = <&gpio2 RK_PB0 GPIO_ACTIVE_HIGH>;//BL
+		dc-gpios = <&gpio2 RK_PB1 GPIO_ACTIVE_HIGH>;//DC
+		reset-gpios = <&gpio1 RK_PC3 GPIO_ACTIVE_LOW>;//RES
+	};
+};
+// I2C
+&i2c0 {
+	pinctrl-0 = <&i2c0m2_xfer>;
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1m1_xfer>;
+};
+
+&i2c3 {
+	pinctrl-0 = <&i2c3m1_xfer &i2c3m0_xfer>;
+};
+
+&i2c4 {
+	pinctrl-names = "default", "conifg";
+	pinctrl-0 = <&i2c4m2_xfer>;
+	pinctrl-1 = <&i2c4m0_xfer>;
+};
+
+// UART
+&uart0 {
+	pinctrl-0 = <&uart0m0_xfer &uart0m1_xfer>;
+};
+&uart1 {
+	pinctrl-0 = <&uart1m1_xfer>;
+};
+&uart3 {
+	pinctrl-0 = <&uart3m1_xfer>;
+};
+&uart4 {
+	pinctrl-0 = <&uart4m1_xfer>;
+};
+&uart5 {
+	pinctrl-0 = <&uart5m0_xfer>;
+};
+
+// PWM
+&pwm0 {
+	pinctrl-0 = <&pwm0m1_pins>;
+};
+&pwm2 {
+	pinctrl-0 = <&pwm2m2_pins>;
+};
+&pwm3 {
+	pinctrl-0 = <&pwm3m2_pins>;
+};
+&pwm4 {
+	pinctrl-0 = <&pwm4m2_pins>;
+};
+&pwm5 {
+	pinctrl-0 = <&pwm5m1_pins &pwm5m2_pins>;
+};
+&pwm6 {
+	pinctrl-0 = <&pwm6m1_pins &pwm6m2_pins>;
+};
+&pwm8 {
+	pinctrl-0 = <&pwm8m1_pins>;
+};
+&pwm9 {
+	pinctrl-0 = <&pwm9m1_pins>;
+};
+&pwm10 {
+	pinctrl-0 = <&pwm10m1_pins &pwm10m2_pins>;
+};
+&pwm11 {
+	pinctrl-0 = <&pwm11m1_pins &pwm11m2_pins>;
+};
+
+&pinctrl {
+	spi0 {
+		spi0m0_clk: spi0m0-clk {
+			rockchip,pins = <1 RK_PC1 4 &pcfg_pull_none>;
+		};
+		spi0m0_mosi: spi0m0-mosi {
+			rockchip,pins = <1 RK_PC2 6 &pcfg_pull_none>;
+		};
+		spi0m0_miso: spi0m0-miso {
+			rockchip,pins = <1 RK_PC3 6 &pcfg_pull_none>;
+		};
+		spi0m0_cs0: spi0m0-cs0 {
+			rockchip,pins = <1 RK_PC0 4 &pcfg_pull_none>;
+		};
+	};
+
+	gpio1-pc7 {
+		gpio1_pc7: gpio1-pc7 {
+			rockchip,pins = <1 RK_PC7 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+};
+
+

--- a/arch/arm/boot/dts/rv1106g-luckfox-pico-pro-max.dts
+++ b/arch/arm/boot/dts/rv1106g-luckfox-pico-pro-max.dts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2022 Rockchip Electronics Co., Ltd.
+ */
+
+/dts-v1/;
+
+#include "rv1106.dtsi"
+#include "rv1106-evb.dtsi"
+#include "rv1106-luckfox-pico-pro-max-ipc.dtsi"
+
+/ {
+	model = "Luckfox Pico Pro Max";
+	compatible = "rockchip,rv1103g-38x38-ipc-v10", "rockchip,rv1106g3";
+};
+
+/**********CRU**********/
+//&cru {
+//	assigned-clocks =
+//		<&cru PLL_GPLL>, <&cru PLL_CPLL>,
+//		<&cru ARMCLK>,
+//		<&cru ACLK_PERI_ROOT>, <&cru HCLK_PERI_ROOT>,
+//		<&cru PCLK_PERI_ROOT>, <&cru ACLK_BUS_ROOT>,
+//		<&cru PCLK_TOP_ROOT>, <&cru PCLK_PMU_ROOT>,
+//		<&cru HCLK_PMU_ROOT>, <&cru CLK_500M_SRC>;
+//	assigned-clock-rates =
+//		<1188000000>, <700000000>,
+//		<1104000000>,
+//		<400000000>, <200000000>,
+//		<100000000>, <300000000>,
+//		<100000000>, <100000000>,
+//		<200000000>, <700000000>;
+//};
+
+/**********NPU**********/
+//&npu {
+//	assigned-clock-rates = <700000000>;
+//};
+
+/**********FLASH**********/
+&sfc {
+	status = "okay";
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <75000000>;
+		spi-rx-bus-width = <4>;
+		spi-tx-bus-width = <1>;
+	};
+};
+
+/**********SDMMC**********/
+&sdmmc {
+	max-freqency = <50000000>;
+	no-mmc;
+	bus-width = <4>;
+	cap-mmc-highspeed;
+	cap-sd-highspeed;
+	disable-wp;
+
+	//sdio
+	cap-sdio-irq;
+	non-removable;
+	no-1-8-v;
+	supports-sdio;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&sdmmc0_clk &sdmmc0_cmd &sdmmc0_det &sdmmc0_bus4>;
+	status = "okay";
+};
+
+/**********ETH**********/
+&gmac {
+	status = "okay";
+};
+
+/**********USB**********/
+&u2phy {
+	status = "okay";
+};
+
+&u2phy_otg {
+	rockchip,dis-u2-susphy;
+	status = "okay";
+};
+
+&usbdrd {
+	status = "okay";
+};
+
+&usbdrd_dwc3 {
+	status = "okay";
+	dr_mode = "peripheral";
+};
+
+/**********SPI**********/
+&spi0 {
+	status = "okay";
+	spidev@0 {
+		spi-max-frequency = <50000000>;
+	};
+	fbtft@0 {
+		spi-max-frequency = <50000000>;
+	};
+};
+
+/**********I2C**********/
+/* I2C3_M1 */
+&i2c3 {
+	status = "okay";
+	clock-frequency = <100000>;
+};
+
+/* I2C1_M1 */
+&i2c1 {
+	status = "okay";
+	clock-frequency = <100000>;
+};
+
+
+/**********UART**********/
+/* UART3_M1 */
+&uart3 {
+	status = "disabled";
+};
+
+/* UART4_M1 */
+&uart4 {
+	status = "disabled";
+};
+
+/**********RTC**********/
+&rtc {
+	status = "okay";
+};


### PR DESCRIPTION
Adds support for RV1106g2 / RV1106g3 board: [Luckfox Pico Pro / Luckfox Pico Max](https://wiki.luckfox.com/Luckfox-Pico-RV1106#luckfox-pico-promax)

~DRAFT -- depends on OP-TEE changes in #409~