### PR TITLE
arch: arm: dts: add Luckfox Lyra Ultra W

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -1228,6 +1228,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
 	rk3506b-armsom-forge1.dtb \
 	rk3506b-evb1-v10.dtb \
 	rk3506b-test2-v10.dtb \
+	rk3506b-luckfox-lyra-ultra-w.dtb \
 	rk3506b-luckfox-lyra-zero-w-sd.dtb \
 	rk3506g-demo-display-control.dtb \
 	rk3506g-evb1-v10.dtb \

--- a/arch/arm/boot/dts/rk3506b-luckfox-lyra-ultra-w.dts
+++ b/arch/arm/boot/dts/rk3506b-luckfox-lyra-ultra-w.dts
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2024 Rockchip Electronics Co., Ltd.
+ */
+
+/dts-v1/;
+
+#include "rk3506-luckfox-lyra-ultra.dtsi"
+
+/ {
+	model = "Luckfox Lyra Ultra W";
+	compatible = "rockchip,rk3506g-demo-display-control", "rockchip,rk3506";
+
+	//acodec_sound: acodec-sound {
+	//	compatible = "simple-audio-card";
+	//	simple-audio-card,name = "rockchip-acodec-sound";
+	//	simple-audio-card,format = "i2s";
+	//	simple-audio-card,mclk-fs = <1024>;
+	//	simple-audio-card,bitclock-master = <&codec_master>;
+	//	simple-audio-card,frame-master = <&codec_master>;
+	//	simple-audio-card,cpu {
+	//		sound-dai = <&sai4>;
+	//	};
+	//	codec_master: simple-audio-card,codec {
+	//		sound-dai = <&audio_codec>;
+	//	};
+	//};
+
+	dsm_sound: dsm-sound {
+		status = "okay";
+		compatible = "simple-audio-card";
+		simple-audio-card,format = "i2s";
+		simple-audio-card,mclk-fs = <256>;
+		simple-audio-card,name = "rockchip-dsm-sound";
+		simple-audio-card,bitclock-master = <&dsm_master>;
+		simple-audio-card,frame-master = <&dsm_master>;
+		simple-audio-card,cpu {
+			sound-dai = <&sai3>;
+		};
+		dsm_master: simple-audio-card,codec {
+			sound-dai = <&acdcdig_dsm>;
+		};
+	};
+
+	wireless_bluetooth: wireless-bluetooth {
+		compatible = "bluetooth-platdata";
+		BT,power_gpio = <&gpio1 RK_PC5 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+	};
+
+	vcc3v3_lcd: vcc3v3-lcd {
+		status = "okay";
+		compatible = "regulator-fixed";
+		pinctrl-names = "default";
+		pinctrl-0 = <&lcd_pwren_h>;
+		regulator-name = "vcc3v3_lcd";
+		regulator-always-on;
+	};
+};
+
+/**********media**********/
+&mmc{
+	/* For eMMC */
+	max-frequency = <52000000>;
+	mmc-ddr-1_8v;
+	bus-width = <4>;
+	supports-emmc;
+	cap-mmc-highspeed;
+	disable-wp;
+	//no-sd;
+	//no-sdio;
+	non-removable;
+	pinctrl-names = "default";
+	pinctrl-0 = <&sdmmc_clk_pins &sdmmc_cmd_pins &sdmmc_bus4_pins>;
+	status = "okay";
+};
+
+&fspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		spi-rx-bus-width = <4>;
+		spi-tx-bus-width = <1>;
+	};
+};
+
+/**********display**********/
+&cma {
+	size = <0x400000>;
+};
+
+&dsi {
+	status = "okay";
+};
+
+&dsi_dphy {
+	status = "okay";
+};
+
+&dsi_in_vop {
+	status = "okay";
+};
+
+&route_dsi {
+	status = "okay";
+};
+
+&dsi_panel {
+	power-supply = <&vcc3v3_lcd>;
+};
+
+/**********ethernet**********/
+&gmac1 {
+	phy-mode = "rmii";
+	clock_in_out = "output";
+
+	snps,reset-gpio = <&gpio1 RK_PD0 GPIO_ACTIVE_LOW>;
+	snps,reset-active-low;
+	snps,reset-delays-us = <0 20000 100000>;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_rmii1_miim_pins &eth_rmii1_tx_bus2_pins &eth_rmii1_rx_bus2_pins &eth_rmii1_clk_pins>;
+
+	phy-handle = <&rmii_phy1>;
+	status = "okay";
+};
+
+&mdio1 {
+	rmii_phy1: phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0x1>;
+	};
+};
+
+/**********usb**********/
+&usb20_otg0 {
+	dr_mode = "host";
+	status = "okay";
+};
+
+&usb20_otg1 {
+	dr_mode = "host";
+	status = "okay";
+};
+
+/**********audio**********/
+&sai4 {
+	status = "okay";
+};
+
+&audio_codec {
+	status = "okay";
+};
+
+&sai3 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&sai3_mclk_pins>;
+};
+
+&acdcdig_dsm {
+	rockchip,dsm-audm-en = <0x2>; // 0x2: enable dsm1
+	pa-ctl-gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+};
+
+/**********rtc**********/
+&i2c2 {
+	tcs8563: tcs8563@51 {
+		status = "okay";
+		compatible = "nxp,pcf8563";
+		reg = <0x51>;
+		#clock-cells = <0>;
+	};
+};
+
+/**********pinctrl**********/
+&pinctrl {
+	lcd {
+		lcd_pwren_h: lcd-pwren-h {
+			rockchip,pins = <1 RK_PC4 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+	};
+
+	acodec-dsm {
+		/omit-if-no-ref/
+		dsm_spk_ctrl: dsm-spk-ctrl {
+			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
+	dsm_aud {
+		/omit-if-no-ref/
+		dsm_audm1_pins: dsm-audm1-pins {
+			rockchip,pins =
+				/* dsm_aud_rn_m1 */
+				<2 RK_PB4 2 &pcfg_pull_none>,
+				/* dsm_aud_rp_m1 */
+				<2 RK_PB5 2 &pcfg_pull_none>;
+		};
+
+		/omit-if-no-ref/
+		dsm_audm1_iodown_pins: dsm-audm1-iodown-pins {
+			rockchip,pins =
+				/* dsm_aud_rn_m1 */
+				<2 RK_PB4 RK_FUNC_GPIO &pcfg_pull_down>,
+				/* dsm_aud_rp_m1 */
+				<2 RK_PB5 RK_FUNC_GPIO &pcfg_pull_down>;
+		};
+	};
+};


### PR DESCRIPTION
Adds devicetree for RK3506B board: [Luckfox Lyra Ultra W](https://wiki.luckfox.com/Luckfox-Lyra/Introduction/)

Tested / working
<img width="982" height="587" alt="image" src="https://github.com/user-attachments/assets/79c36d72-1d9e-4fe1-9abc-9640d814a632" />
