### PR TITLE
Add PWM configuration to rk3506b-armsom-forge1.dts

### DIFF
--- a/arch/arm/boot/dts/rk3506b-armsom-forge1.dts
+++ b/arch/arm/boot/dts/rk3506b-armsom-forge1.dts
@@ -236,6 +236,12 @@
 	status = "okay";
 };
 
+&pwm0_4ch_0 {
+	pinctrl-names = "active";
+	pinctrl-0 = <&rm_io21_pwm0_ch0>;
+	status = "okay";
+};
+
 &pinctrl {
     ethernet {
 		rmii0_rstn: rmii0-rstn {


### PR DESCRIPTION
Enables CPU to be controlled via PWM.