### PR TITLE
Action: Upload arm64 artifacts too

### DIFF
--- a/.github/workflows/compile.yaml
+++ b/.github/workflows/compile.yaml
@@ -50,7 +50,6 @@ jobs:
         id: kernel-armhf
         run: |
 
-          rm -rf output/debs/*
           mkdir -p userpatches/extensions/
           cat <<- EOF > userpatches/extensions/pull-request.sh
           function post_family_config__force_commit_for_rk3588() {


### PR DESCRIPTION
The action compiles the arm64 kernel then cleans the output folder then builds the armhf kernel only which later gets uploaded since it is the only output.