### PR TITLE
youyeetoo-r1: fix CAN2/UART5 pin conflict

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-yyt-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-yyt-common.dtsi
@@ -588,7 +588,7 @@
 /* CAN */
 &can2 {
     pinctrl-names = "default";
-    pinctrl-0 = <&can2m0_pins>;
+    pinctrl-0 = <&can2m1_pins>; /* GPIO0_PD4/PD5 (pins 20,22) to avoid conflict with UART5 */
     status = "okay";
 };
 


### PR DESCRIPTION
Change CAN2 from m0 to m1 mux to resolve GPIO conflict. CAN2 now uses GPIO0_PD4/PD5 (pins 20,22) instead of GPIO3_PC4/PC5.