### PR TITLE
youyeetoo-r1: use ES8323 driver for ES8388 audio codec

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-youyeetoo-r1.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-youyeetoo-r1.dts
@@ -12,12 +12,12 @@
     model = "Youyeetoo R1";
     compatible = "youyeetoo,r1", "rockchip,rk3588";
 
-    /* AUDIO */
+    /* AUDIO - ES8388 chip, but only works with ES8323 driver */
 
-	es8388_sound: es8388-sound {
+	es8323_sound: es8323-sound {
 		status = "okay";
 		compatible = "rockchip,multicodecs-card";
-		rockchip,card-name = "rockchip-es8388";
+		rockchip,card-name = "rockchip-es8323";
         hp-det-gpio = <&gpio1 RK_PC0 GPIO_ACTIVE_LOW>;
 		io-channels = <&saradc 3>;
 		io-channel-names = "adc-detect";
@@ -26,7 +26,7 @@
 		rockchip,format = "i2s";
 		rockchip,mclk-fs = <256>;
 		rockchip,cpu = <&i2s0_8ch>;
-		rockchip,codec = <&es8388>;
+		rockchip,codec = <&es8323>;
         rockchip,audio-routing =
             "Headphone", "LOUT1",
             "Headphone", "ROUT1",

--- a/arch/arm64/boot/dts/rockchip/rk3588s-yyt-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-yyt-common.dtsi
@@ -273,10 +273,11 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c7m0_xfer>;
 
-	es8388: es8388@11 {
+	/* Audio codec: ES8388 chip, but only works with ES8323 driver */
+	es8323: es8323@11 {
 		status = "okay";
 		#sound-dai-cells = <0>;
-		compatible = "everest,es8388", "everest,es8323";
+		compatible = "everest,es8323";
 		reg = <0x11>;
 		clocks = <&mclkout_i2s0>;
 		clock-names = "mclk";


### PR DESCRIPTION
The ES8388 chip works only with ES8323 driver in mainline kernel. Rename all nodes and use only "everest,es8323" compatible string.