### PR TITLE
Overlay: For rock-5t add radxa cam4k for cam0 and cam1

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/rock-5t-radxa-camera-4k-on-cam0.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/rock-5t-radxa-camera-4k-on-cam0.dts
@@ -1,0 +1,210 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/rk3588-cru.h>
+#include <dt-bindings/power/rk3588-power.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
+/ {
+	metadata {
+		title ="Enable Radxa Camera 4K on CAM0";
+		compatible = "radxa,rock-5t", "radxa,rock-5t-industrial";
+		category = "camera";
+		exclusive = "csi2_dphy0";
+		description = "Enable Radxa Camera 4K on CAM0.";
+	};
+};
+
+/ {
+	fragment@0 {
+		target = <&i2c3>;
+
+		__overlay__ {
+			status = "okay";
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			imx415: imx415@1a {
+				status = "okay";
+				compatible = "sony,imx415";
+				reg = <0x1a>;
+				clocks = <&cru CLK_MIPI_CAMARAOUT_M3>;
+				clock-names = "xvclk";
+				pinctrl-names = "default";
+				pinctrl-0 = <&mipim0_camera3_clk>;
+				power-domains = <&power RK3588_PD_VI>;
+                pwdn-gpios = <&gpio1 RK_PD3 GPIO_ACTIVE_HIGH>;
+                reset-gpios = <&gpio2 RK_PC5 GPIO_ACTIVE_LOW>;
+				rockchip,camera-module-index = <0>;
+				rockchip,camera-module-facing = "front";
+				rockchip,camera-module-name = "RADXA-CAMERA-4K";
+				rockchip,camera-module-lens-name = "DEFAULT";
+
+				port {
+					imx415_out0: endpoint {
+						remote-endpoint = <&mipidphy0_in_ucam0>;
+						data-lanes = <1 2 3 4>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&csi2_dphy0_hw>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@2 {
+		target = <&csi2_dphy0>;
+
+		__overlay__ {
+			status = "okay";
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					mipidphy0_in_ucam0: endpoint@1 {
+						reg = <1>;
+						remote-endpoint = <&imx415_out0>;
+						data-lanes = <1 2 3 4>;
+					};
+				};
+
+				port@1 {
+					reg = <1>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					csidphy0_out: endpoint@0 {
+						reg = <0>;
+						remote-endpoint = <&mipi2_csi2_input>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@3 {
+		target = <&mipi2_csi2>;
+
+		__overlay__ {
+			status = "okay";
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					mipi2_csi2_input: endpoint@1 {
+						reg = <1>;
+						remote-endpoint = <&csidphy0_out>;
+					};
+				};
+
+				port@1 {
+					reg = <1>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					mipi2_csi2_output: endpoint@0 {
+						reg = <0>;
+						remote-endpoint = <&cif_mipi2_in0>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@4 {
+		target = <&rkcif>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@5 {
+		target = <&rkcif_mipi_lvds2>;
+
+		__overlay__ {
+			status = "okay";
+
+			port {
+				cif_mipi2_in0: endpoint {
+					remote-endpoint = <&mipi2_csi2_output>;
+				};
+			};
+		};
+	};
+
+	fragment@6 {
+		target = <&rkcif_mipi_lvds2_sditf>;
+
+		__overlay__ {
+			status = "okay";
+
+			port {
+				mipi_lvds2_sditf: endpoint {
+					remote-endpoint = <&isp0_vir0>;
+				};
+			};
+		};
+	};
+
+	fragment@7 {
+		target = <&rkcif_mmu>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@8 {
+		target = <&isp0_mmu>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@9 {
+		target = <&rkisp0>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@10 {
+		target = <&rkisp0_vir0>;
+
+		__overlay__ {
+			status = "okay";
+
+			port {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				isp0_vir0: endpoint@0 {
+					reg = <0>;
+					remote-endpoint = <&mipi_lvds2_sditf>;
+				};
+			};
+		};
+	};
+};


### PR DESCRIPTION
- [x] do static syntax check 
   - `gcc -E -nostdinc -undef -x assembler-with-cpp -I ./include arch/arm64/boot/dts/rockchip/overlay/rock-5t-radxa-camera-4k-on-cam0.dts` 
- [x] do preprocess check
   - `gcc -E -nostdinc -undef -x assembler-with-cpp -I ./include arch/arm64/boot/dts/rockchip/overlay/rock-5t-radxa-camera-4k-on-cam0.dts > rock-5t-radxa-camera-4k-on-cam0.dts.preprocessed`  
- [x] compile 
   - [ ] dtbs_check : could not figure this out , `make ARCH=arm64 CROSS_COMPILE=aarch64-linux-gnu- dtbs_check` takes a lot of time .
- [ ] test camera
- [ ] repeat for cam1 port