### PR TITLE
Fix memory leaks in DCN clock source creation functions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:conda",
+    "python-envs.defaultPackageManager": "ms-python.python:conda",
+    "python-envs.pythonProjects": []
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "python-envs.defaultEnvManager": "ms-python.python:conda",
-    "python-envs.defaultPackageManager": "ms-python.python:conda",
-    "python-envs.pythonProjects": []
-}

--- a/drivers/gpu/drm/amd/display/dc/dce80/dce80_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dce80/dce80_resource.c
@@ -1533,6 +1533,7 @@ struct resource_pool *dce83_create_resource_pool(
 	if (dce83_construct(num_virtual_links, dc, pool))
 		return &pool->base;
 
+	kfree(pool);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }

--- a/drivers/gpu/drm/amd/display/dc/dcn30/dcn30_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn30/dcn30_resource.c
@@ -1328,6 +1328,7 @@ static struct clock_source *dcn30_clock_source_create(
 		return &clk_src->base;
 	}
 
+	kfree(clk_src);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }

--- a/drivers/gpu/drm/amd/display/dc/dcn301/dcn301_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn301/dcn301_resource.c
@@ -1288,6 +1288,7 @@ static struct clock_source *dcn301_clock_source_create(
 		return &clk_src->base;
 	}
 
+	kfree(clk_src);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }

--- a/drivers/gpu/drm/amd/display/dc/dcn302/dcn302_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn302/dcn302_resource.c
@@ -464,6 +464,7 @@ static struct clock_source *dcn302_clock_source_create(struct dc_context *ctx, s
 		return &clk_src->base;
 	}
 
+	kfree(clk_src);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }

--- a/drivers/gpu/drm/amd/display/dc/dcn303/dcn303_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn303/dcn303_resource.c
@@ -431,6 +431,7 @@ static struct clock_source *dcn303_clock_source_create(struct dc_context *ctx, s
 		return &clk_src->base;
 	}
 
+	kfree(clk_src);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }

--- a/drivers/gpu/drm/amd/display/dc/dcn31/dcn31_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn31/dcn31_resource.c
@@ -2211,7 +2211,7 @@ struct resource_pool *dcn31_create_resource_pool(
 	if (dcn31_resource_construct(init_data->num_virtual_links, dc, pool))
 		return &pool->base;
 
-	BREAK_TO_DEBUGGER();
 	kfree(pool);
+	BREAK_TO_DEBUGGER();
 	return NULL;
 }

--- a/drivers/gpu/drm/amd/display/dc/dcn31/dcn31_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn31/dcn31_resource.c
@@ -1629,6 +1629,7 @@ static struct clock_source *dcn31_clock_source_create(
 		return &clk_src->base;
 	}
 
+	kfree(clk_src);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }
@@ -1865,6 +1866,7 @@ static struct clock_source *dcn30_clock_source_create(
 		return &clk_src->base;
 	}
 
+	kfree(clk_src);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }

--- a/drivers/gpu/drm/amd/display/dc/dcn314/dcn314_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn314/dcn314_resource.c
@@ -1676,8 +1676,8 @@ static struct clock_source *dcn31_clock_source_create(
 		return &clk_src->base;
 	}
 
-	BREAK_TO_DEBUGGER();
 	kfree(clk_src);
+	BREAK_TO_DEBUGGER();
 	return NULL;
 }
 
@@ -1830,8 +1830,8 @@ static struct clock_source *dcn30_clock_source_create(
 		return &clk_src->base;
 	}
 
-	BREAK_TO_DEBUGGER();
 	kfree(clk_src);
+	BREAK_TO_DEBUGGER();
 	return NULL;
 }
 

--- a/drivers/gpu/drm/amd/display/dc/dcn315/dcn315_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn315/dcn315_resource.c
@@ -1630,6 +1630,7 @@ static struct clock_source *dcn31_clock_source_create(
 		return &clk_src->base;
 	}
 
+	kfree(clk_src);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }

--- a/drivers/gpu/drm/amd/display/dc/dcn32/dcn32_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn32/dcn32_resource.c
@@ -830,6 +830,7 @@ static struct clock_source *dcn32_clock_source_create(
 		return &clk_src->base;
 	}
 
+	kfree(clk_src);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }

--- a/drivers/gpu/drm/amd/display/dc/dcn321/dcn321_resource.c
+++ b/drivers/gpu/drm/amd/display/dc/dcn321/dcn321_resource.c
@@ -829,6 +829,7 @@ static struct clock_source *dcn321_clock_source_create(
 		return &clk_src->base;
 	}
 
+	kfree(clk_src);
 	BREAK_TO_DEBUGGER();
 	return NULL;
 }


### PR DESCRIPTION
This patch fixes multiple memory leak issues in several DCN3.x clock_source_create() and create_resource_pool() implementations. These functions allocate clk_src via kzalloc(), but on construct failure some of them return NULL without freeing the allocated memory. This mirrors the same class of issue previously fixed in commit 055e547478a1 ("drm/amd/display: fix leak in clock_source_create()"), which addressed leaks in earlier DCE/DCN generations.

For consistency and correctness, this patch ensures that all affected DCE80/DCN30/DCN31/DCN32/DCN3xx clock_source_create() functions explicitly call kfree() before hitting BREAK_TO_DEBUGGER() and returning NULL.

No functional behavior is changed in the success path. Only failure paths are corrected to guarantee proper cleanup.

---

### Files and functions updated:

- dcn301_resource.c  – dcn301_clock_source_create
- dcn321_resource.c  – dcn321_clock_source_create
- dcn315_resource.c  – dcn31_clock_source_create
- dcn314_resource.c  – dcn31_clock_source_create (order corrected)
- dcn314_resource.c  – dcn30_clock_source_create (order corrected)
- dcn32_resource.c   – dcn32_clock_source_create
- dcn30_resource.c   – dcn30_clock_source_create
- dcn31_resource.c   – dcn31_clock_source_create
- dcn31_resource.c   – dcn30_clock_source_create
- dcn302_resource.c  – dcn302_clock_source_create
- dcn303_resource.c  – dcn303_clock_source_create

resource pool fixes:

- dce80_resource.c  – dce83_create_resource_pool (add missing kfree(pool))
- dcn31_resource.c  – dcn31_create_resource_pool (fix kfree/BREAK_TO_DEBUGGER ordering)

---

### Motivation

All these clock_source_create() functions follow the same ownership model as earlier DCE/DCN implementations: the allocation is local to the function, and a failure during construct() does not hand the pointer to any external structure. Thus the caller becomes the sole owner of clk_src during the failure path, and it must be freed explicitly before returning NULL.

Missing kfree() results in memory leaks, especially during repeated resource pool construction attempts or probe retries. The fix aligns these implementations with the correct error-handling pattern already established in upstream DC/DCE code.

Similarly, dce83_create_resource_pool() in the DCE80 path suffered from the same class of leak, which is now fixed by adding the missing kfree(pool), and dcn31_create_resource_pool() now frees its pool before BREAK_TO_DEBUGGER() is hit on failure.

---

### Changes

- Add missing `kfree(clk_src);` before `BREAK_TO_DEBUGGER();`
- Ensure kfree() always precedes BREAK_TO_DEBUGGER() for consistent
  and safe cleanup semantics across all DCN3.x implementations.
- Add missing `kfree(pool);` in dce83_create_resource_pool(), matching the
  upstream fix for the memleak in this path.
- Fix the ordering between kfree(pool) and BREAK_TO_DEBUGGER() in
  dcn31_create_resource_pool() so that cleanup is guaranteed to happen
  before any debug break.
- No behavioral changes in success paths.

