### PR TITLE
RK3506: Add overlay support / add overlays to disable Ethernet ifaces

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -1733,3 +1733,7 @@ dtb-$(CONFIG_ARCH_ASPEED) += \
 	aspeed-bmc-vegman-n110.dtb \
 	aspeed-bmc-vegman-rx20.dtb \
 	aspeed-bmc-vegman-sx20.dtb
+
+subdir-y := $(dts-dirs) overlay
+
+# Armbian: Incremental: assuming overlay targets are already in the Makefile

--- a/arch/arm/boot/dts/overlay/Makefile
+++ b/arch/arm/boot/dts/overlay/Makefile
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: GPL-2.0
+dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+	rockchip-rk3506-disable-ethernet0.dtbo \
+	rockchip-rk3506-disable-ethernet1.dtbo
+
+dtbotxt-$(CONFIG_ARCH_ROCKCHIP) += \
+	README.rockchip-overlays
+
+targets += $(dtbo-y) $(dtbotxt-y)
+
+always-y		:= $(dtbo-y) $(dtbotxt-y)
+clean-files		:= *.dtbo
+

--- a/arch/arm/boot/dts/overlay/README.rockchip-overlays
+++ b/arch/arm/boot/dts/overlay/README.rockchip-overlays
@@ -1,0 +1,21 @@
+This document describes overlays provided in the kernel packages
+For generic Armbian overlays documentation please see
+https://docs.armbian.com/User-Guide_Armbian_overlays/
+
+### Platform:
+
+rockchip (Rockchip)
+with vendor-kernel
+
+### Provided overlays:
+
+for RK3506:
+- disable-ethernet0, disable-ethernet1
+
+### Overlay details:
+
+### rk3506-disable-ethernet0
+Disables `end0` ethernet adapter (`gmac0`, `mdio0`) to save power.
+
+### rk3506-disable-ethernet1
+Disables `end1` ethernet adapter (`gmac1`, `mdio1`) to save power.

--- a/arch/arm/boot/dts/overlay/rockchip-rk3506-disable-ethernet0.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-rk3506-disable-ethernet0.dts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Disable ethernet0 for power optimization
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Disable Ethernet 0";
+		compatible = "rockchip,rk3506";
+		category = "misc";
+		exclusive = "gmac0";
+		description = "Disable ethernet0 (gmac0) for power optimization.";
+	};
+};
+
+&gmac0 {
+	status = "disabled";
+};
+
+&mdio0 {
+	status = "disabled";
+};

--- a/arch/arm/boot/dts/overlay/rockchip-rk3506-disable-ethernet1.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-rk3506-disable-ethernet1.dts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Disable ethernet1 for power optimization
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Disable Ethernet 1";
+		compatible = "rockchip,rk3506";
+		category = "misc";
+		exclusive = "gmac1";
+		description = "Disable ethernet1 (gmac1) for power optimization.";
+	};
+};
+
+&gmac1 {
+	status = "disabled";
+};
+
+&mdio1 {
+	status = "disabled";
+};


### PR DESCRIPTION
Add support for adding overlays on `arm` (armhf).

Add generic rk3506 overlays for disabling ethernet ifaces.


Tested with https://github.com/armbian/build/pull/9396 -- working!