### PR TITLE
fix(orangepi5max): change usbdrd_dwc3_0 mode from otg to host

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-max.dts
@@ -1177,7 +1177,7 @@
 
 &usbdrd_dwc3_0 {
 	status = "okay";
-	dr_mode = "otg";
+	dr_mode = "host";
 	extcon = <&u2phy0>;
 };
 


### PR DESCRIPTION
fix USB3 port 0 issue for orangepi5max, same fix as https://github.com/armbian/linux-rockchip/pull/217 (orangepi5pro), changed dr_mode from otg to host.
tested and confirmed working.