### PR TITLE
RK3506: Add spidev overlays for RK3506 family

### DIFF
--- a/arch/arm/boot/dts/overlay/Makefile
+++ b/arch/arm/boot/dts/overlay/Makefile
@@ -1,5 +1,17 @@
 # SPDX-License-Identifier: GPL-2.0
 dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
+	rockchip-forlinx-ok3506-s12-spi0-1cs-spidev.dtbo \
+	rockchip-forlinx-ok3506-s12-spi0-2cs-spidev.dtbo \
+	rockchip-forlinx-ok3506-s12-spi1-1cs-spidev.dtbo \
+	rockchip-forlinx-ok3506-s12-spi1-2cs-spidev.dtbo \
+	rockchip-luckfox-lyra-plus-spi0-1cs_rmio13-spidev.dtbo \
+	rockchip-luckfox-lyra-plus-spi0-1cs-spidev.dtbo \
+	rockchip-luckfox-lyra-plus-spi0-2cs-spidev.dtbo \
+	rockchip-luckfox-lyra-ultra-w-spi0-1cs-spidev.dtbo \
+	rockchip-luckfox-lyra-zero-w-spi0-1cs-spidev.dtbo \
+	rockchip-luckfox-lyra-zero-w-spi0-2cs-spidev.dtbo \
+	rockchip-luckfox-lyra-zero-w-spi1-1cs-spidev.dtbo \
+	rockchip-luckfox-lyra-zero-w-spi1-2cs-spidev.dtbo \
 	rockchip-rk3506-disable-ethernet0.dtbo \
 	rockchip-rk3506-disable-ethernet1.dtbo
 

--- a/arch/arm/boot/dts/overlay/README.rockchip-overlays
+++ b/arch/arm/boot/dts/overlay/README.rockchip-overlays
@@ -10,7 +10,28 @@ with vendor-kernel
 ### Provided overlays:
 
 for RK3506:
-- disable-ethernet0, disable-ethernet1
+- disable-ethernet0
+- disable-ethernet1
+
+for Forlinx OK3506-S12:
+- spi0-1cs-spidev
+- spi0-2cs-spidev
+- spi1-1cs-spidev
+- spi1-2cs-spidev
+
+for Luckfox Lyra Plus:
+- spi0-1cs-spidev
+- spi0-1cs_rmio13-spidev
+- spi0-2cs-spidev
+
+for Luckfox Lyra Ultra W:
+- spi0-1cs-spidev
+
+for Luckfox Lyra Zero W:
+- spi0-1cs-spidev
+- spi0-2cs-spidev
+- spi1-1cs-spidev
+- spi1-2cs-spidev
 
 ### Overlay details:
 
@@ -19,3 +40,51 @@ Disables `end0` ethernet adapter (`gmac0`, `mdio0`) to save power.
 
 ### rk3506-disable-ethernet1
 Disables `end1` ethernet adapter (`gmac1`, `mdio1`) to save power.
+
+### forlinx-ok3506-s12-spi0-1cs-spidev
+Enables SPI0 spidev on forlinx-ok3506-s12 with one chipselect.
+Compatible with Raspberry Pi 'spi0-1cs' hats.
+
+### forlinx-ok3506-s12-spi0-2cs-spidev
+Enables SPI0 spidev on forlinx-ok3506-s12 with two chipselects.
+Compatible with Raspberry Pi 'spi0-2cs' hats.
+
+### forlinx-ok3506-s12-spi1-1cs-spidev
+Enables SPI1 spidev on forlinx-ok3506-s12 with one chipselect.
+Compatible with Raspberry Pi 'spi1-1cs' hats.
+
+### forlinx-ok3506-s12-spi1-2cs-spidev
+Enables SPI1 spidev on forlinx-ok3506-s12 with two chipselects.
+Compatible with Raspberry Pi 'spi1-2cs' hats.
+
+### luckfox-lyra-plus-spi0-1cs-spidev
+Enables SPI0 spidev on luckfox-lyra-plus with one chipselect (CS0 = RM_IO8).
+Retains pin-compatibility with Luckfox Pico Plus.
+
+### luckfox-lyra-plus-spi0-1cs_rmio13-spidev
+Enables SPI0 spidev on luckfox-lyra-plus with CS0 on RM_IO13.
+For Waveshare Pi Pico LoRa Hat which uses RM_IO13 as CS.
+
+### luckfox-lyra-plus-spi0-2cs-spidev
+Enables SPI0 spidev on luckfox-lyra-plus with two chipselects.
+Retains pin-compatibility with Luckfox Pico Plus.
+
+### luckfox-lyra-ultra-w-spi0-1cs-spidev
+Enables SPI0 spidev on luckfox-lyra-ultra-w with one chipselect.
+Retains pin-compatibility with Luckfox Pico Ultra.
+
+### luckfox-lyra-zero-w-spi0-1cs-spidev
+Enables SPI0 spidev on luckfox-lyra-zero-w with one chipselect.
+Compatible with Raspberry Pi 'spi0-1cs' hats.
+
+### luckfox-lyra-zero-w-spi0-2cs-spidev
+Enables SPI0 spidev on luckfox-lyra-zero-w with two chipselects.
+Compatible with Raspberry Pi 'spi0-2cs' hats.
+
+### luckfox-lyra-zero-w-spi1-1cs-spidev
+Enables SPI1 spidev on luckfox-lyra-zero-w with one chipselect.
+Compatible with Raspberry Pi 'spi1-1cs' hats.
+
+### luckfox-lyra-zero-w-spi1-2cs-spidev
+Enables SPI1 spidev on luckfox-lyra-zero-w with two chipselects.
+Compatible with Raspberry Pi 'spi1-2cs' hats.

--- a/arch/arm/boot/dts/overlay/rockchip-forlinx-ok3506-s12-spi0-1cs-spidev.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-forlinx-ok3506-s12-spi0-1cs-spidev.dts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Enable spidev on SPI0 with standard RM_IO pinmux:
+ * MOSI = RM_IO17, MISO = RM_IO18, CLK = RM_IO16, CS0 = RM_IO19
+ * Compatible with Raspberry Pi 'spi0-1cs' hats
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SPI0 spidev on forlinx-ok3506-s12";
+		compatible = "forlinx,ok3506";
+		category = "spi";
+		exclusive = "spi0", "RM_IO16", "RM_IO17", "RM_IO18", "RM_IO19";
+		description = "Enable SPI0 spidev using RM_IO17(MOSI), RM_IO18(MISO), RM_IO16(CLK), RM_IO19(CS0).";
+	};
+};
+
+&spi0 {
+	status = "okay";
+	num-cs = <1>;
+
+	spi@0 {
+		status = "okay";
+	};
+};

--- a/arch/arm/boot/dts/overlay/rockchip-forlinx-ok3506-s12-spi0-2cs-spidev.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-forlinx-ok3506-s12-spi0-2cs-spidev.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Enable spidev on SPI0 with standard RM_IO pinmux:
+ * MOSI = RM_IO17, MISO = RM_IO18, CLK = RM_IO16, CS0 = RM_IO19, CS1 = RM_IO15
+ * Compatible with Raspberry Pi 'spi0-2cs' hats
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SPI0 spidev on forlinx-ok3506-s12 with two chipselects";
+		compatible = "forlinx,ok3506";
+		category = "spi";
+		exclusive = "spi0", "RM_IO16", "RM_IO17", "RM_IO18", "RM_IO19", "RM_IO15";
+		description = "Enable SPI0 spidev using RM_IO17(MOSI), RM_IO18(MISO), RM_IO16(CLK), RM_IO19(CS0), RM_IO15(CS1).";
+	};
+};
+
+&spi0 {
+	status = "okay";
+	num-cs = <2>;
+
+	spi@0 {
+		status = "okay";
+	};
+
+	spi@1 {
+		compatible = "rockchip,spidev";
+		reg = <1>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+};

--- a/arch/arm/boot/dts/overlay/rockchip-forlinx-ok3506-s12-spi1-1cs-spidev.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-forlinx-ok3506-s12-spi1-1cs-spidev.dts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Enable spidev on SPI1 with standard RM_IO pinmux:
+ * MOSI = RM_IO9, MISO = RM_IO10, CLK = RM_IO8, CS0 = RM_IO14
+ * Compatible with Raspberry Pi 'spi1-1cs' hats
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SPI1 spidev on forlinx-ok3506-s12";
+		compatible = "forlinx,ok3506";
+		category = "spi";
+		exclusive = "spi1", "RM_IO8", "RM_IO9", "RM_IO10", "RM_IO14";
+		description = "Enable SPI1 spidev using RM_IO9(MOSI), RM_IO10(MISO), RM_IO8(CLK), RM_IO14(CS0).";
+	};
+};
+
+&spi1 {
+	status = "okay";
+	num-cs = <1>;
+
+	spi@0 {
+		status = "okay";
+	};
+};

--- a/arch/arm/boot/dts/overlay/rockchip-forlinx-ok3506-s12-spi1-2cs-spidev.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-forlinx-ok3506-s12-spi1-2cs-spidev.dts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Enable spidev on SPI1 with standard RM_IO pinmux:
+ * MOSI = RM_IO9, MISO = RM_IO10, CLK = RM_IO8, CS0 = RM_IO14, CS1 = RM_IO7
+ * Compatible with Raspberry Pi 'spi1-2cs' hats
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SPI1 spidev on forlinx-ok3506-s12 with two chipselects";
+		compatible = "forlinx,ok3506";
+		category = "spi";
+		exclusive = "spi1", "RM_IO7", "RM_IO8", "RM_IO9", "RM_IO10", "RM_IO14";
+		description = "Enable SPI1 spidev using RM_IO9(MOSI), RM_IO10(MISO), RM_IO8(CLK), RM_IO14(CS0), RM_IO7(CS1).";
+	};
+};
+
+&spi1 {
+	status = "okay";
+	num-cs = <2>;
+
+	spi@0 {
+		status = "okay";
+	};
+
+	spi@1 {
+		compatible = "rockchip,spidev";
+		reg = <1>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+};

--- a/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-plus-spi0-1cs-spidev.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-plus-spi0-1cs-spidev.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Enable spidev on SPI0 with explicit RM_IO pinmux:
+ * MOSI = RM_IO6, MISO = RM_IO5, CLK = RM_IO7, CS0 = RM_IO8
+ * Retains compatibility with luckfox-pico-plus hats (CS0 = RM_IO8).
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SPI0 spidev on luckfox-lyra-plus (CS0 = RM_IO8)";
+		compatible = "rockchip,rk3506g-lyra-plus";
+		category = "spi";
+		exclusive = "spi0", "RM_IO5", "RM_IO6", "RM_IO7", "RM_IO8";
+		description = "Enable SPI0 spidev using RM_IO6(MOSI), RM_IO5(MISO), RM_IO7(CLK), RM_IO8(CS0).";
+	};
+};
+
+&spi0 {
+	status = "okay";
+	num-cs = <1>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&rm_io7_spi0_clk &rm_io5_spi0_miso &rm_io6_spi0_mosi &rm_io8_spi0_csn0>;
+
+	spi@0 {
+		compatible = "rockchip,spidev";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+};

--- a/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-plus-spi0-1cs_rmio13-spidev.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-plus-spi0-1cs_rmio13-spidev.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Compatible with waveshare LoRa Hat for Pi Pico (CS0 = RM_IO13)
+ * Enable spidev on SPI0 with explicit RM_IO pinmux:
+ * MOSI = RM_IO6, MISO = RM_IO5, CLK = RM_IO7, CS0 = RM_IO13
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SPI0 spidev on luckfox-lyra-plus (CS0 = RM_IO13)";
+		compatible = "rockchip,rk3506g-lyra-plus";
+		category = "spi";
+		exclusive = "spi0", "RM_IO5", "RM_IO6", "RM_IO7", "RM_IO13";
+		description = "Enable SPI0 spidev using RM_IO6(MOSI), RM_IO5(MISO), RM_IO7(CLK), RM_IO13(CS0).";
+	};
+};
+
+&spi0 {
+	status = "okay";
+	num-cs = <1>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&rm_io7_spi0_clk &rm_io5_spi0_miso &rm_io6_spi0_mosi &rm_io13_spi0_csn0>;
+
+	spi@0 {
+		compatible = "rockchip,spidev";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+};

--- a/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-plus-spi0-2cs-spidev.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-plus-spi0-2cs-spidev.dts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Enable spidev on SPI0 with explicit RM_IO pinmux:
+ * MOSI = RM_IO6, MISO = RM_IO5, CLK = RM_IO7, CS0 = RM_IO8, CS1 = RM_IO11
+ * Retains compatibility with luckfox-pico-plus hats (CS0 = RM_IO8, CS1 = RM_IO11).
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SPI0 spidev on luckfox-lyra-plus with two chipselects (CS0 = RM_IO8, CS1 = RM_IO11)";
+		compatible = "rockchip,rk3506g-lyra-plus";
+		category = "spi";
+		exclusive = "spi0", "RM_IO5", "RM_IO6", "RM_IO7", "RM_IO8", "RM_IO11";
+		description = "Enable SPI0 spidev using RM_IO6(MOSI), RM_IO5(MISO), RM_IO7(CLK), RM_IO8(CS0), RM_IO11(CS1).";
+	};
+};
+
+&spi0 {
+	status = "okay";
+	num-cs = <2>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&rm_io7_spi0_clk &rm_io5_spi0_miso &rm_io6_spi0_mosi &rm_io8_spi0_csn0 &rm_io11_spi0_csn1>;
+
+	spi@0 {
+		compatible = "rockchip,spidev";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+
+	spi@1 {
+		compatible = "rockchip,spidev";
+		reg = <1>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+};

--- a/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-ultra-w-spi0-1cs-spidev.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-ultra-w-spi0-1cs-spidev.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Enable spidev on SPI0 with explicit RM_IO pinmux:
+ * MOSI = RM_IO6, MISO = RM_IO7, CLK = RM_IO8, CS0 = RM_IO10
+ * Retains compatibility with luckfox-pico-ultra hats
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SPI0 spidev on luckfox-lyra-ultra-w";
+		compatible = "rockchip,rk3506b-lyra-ultra";
+		category = "spi";
+		exclusive = "spi0", "RM_IO6", "RM_IO7", "RM_IO8", "RM_IO10";
+		description = "Enable SPI0 spidev using RM_IO6(MOSI), RM_IO7(MISO), RM_IO8(CLK), RM_IO10(CS0).";
+	};
+};
+
+&spi0 {
+	status = "okay";
+	num-cs = <1>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&rm_io8_spi0_clk &rm_io7_spi0_miso &rm_io6_spi0_mosi &rm_io10_spi0_csn0>;
+
+	spi@0 {
+		compatible = "rockchip,spidev";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+};

--- a/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-zero-w-spi0-1cs-spidev.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-zero-w-spi0-1cs-spidev.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Enable spidev on SPI0 with explicit RM_IO pinmux:
+ * MOSI = RM_IO6, MISO = RM_IO7, CLK = RM_IO8, CS0 = RM_IO10
+ * Compatible with Raspberry Pi 'spi0-1cs' hats
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SPI0 spidev on luckfox-lyra-zero-w";
+		compatible = "rockchip,rk3506b-lyra-zero";
+		category = "spi";
+		exclusive = "spi0", "RM_IO6", "RM_IO7", "RM_IO8", "RM_IO10";
+		description = "Enable SPI0 spidev using RM_IO6(MOSI), RM_IO7(MISO), RM_IO8(CLK), RM_IO10(CS0).";
+	};
+};
+
+&spi0 {
+	status = "okay";
+	num-cs = <1>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&rm_io8_spi0_clk &rm_io7_spi0_miso &rm_io6_spi0_mosi &rm_io10_spi0_csn0>;
+
+	spi@0 {
+		compatible = "rockchip,spidev";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+};

--- a/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-zero-w-spi0-2cs-spidev.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-zero-w-spi0-2cs-spidev.dts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Enable spidev on SPI0 with explicit RM_IO pinmux:
+ * MOSI = RM_IO6, MISO = RM_IO7, CLK = RM_IO8, CS0 = RM_IO10, CS1 = RM_IO9
+ * Compatible with Raspberry Pi 'spi0-2cs' hats
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SPI0 spidev on luckfox-lyra-zero-w with two chipselects";
+		compatible = "rockchip,rk3506b-lyra-zero";
+		category = "spi";
+		exclusive = "spi0", "RM_IO6", "RM_IO7", "RM_IO8", "RM_IO9", "RM_IO10";
+		description = "Enable SPI0 spidev using RM_IO6(MOSI), RM_IO7(MISO), RM_IO8(CLK), RM_IO10(CS0), RM_IO9(CS1).";
+	};
+};
+
+&spi0 {
+	status = "okay";
+	num-cs = <2>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&rm_io8_spi0_clk &rm_io7_spi0_miso &rm_io6_spi0_mosi &rm_io10_spi0_csn0 &rm_io9_spi0_csn1>;
+
+	spi@0 {
+		compatible = "rockchip,spidev";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+
+	spi@1 {
+		compatible = "rockchip,spidev";
+		reg = <1>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+};

--- a/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-zero-w-spi1-1cs-spidev.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-zero-w-spi1-1cs-spidev.dts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Enable spidev on SPI1 with explicit RM_IO pinmux:
+ * MOSI = RM_IO16, MISO = RM_IO17, CLK = RM_IO18, CS0 = RM_IO14
+ * Compatible with Raspberry Pi 'spi1-1cs' hats
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SPI1 spidev on luckfox-lyra-zero-w";
+		compatible = "rockchip,rk3506b-lyra-zero";
+		category = "spi";
+		exclusive = "spi1", "RM_IO14", "RM_IO16", "RM_IO17", "RM_IO18";
+		description = "Enable SPI1 spidev using RM_IO16(MOSI), RM_IO17(MISO), RM_IO18(CLK), RM_IO14(CS0).";
+	};
+};
+
+&spi1 {
+	status = "okay";
+	num-cs = <1>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&rm_io18_spi1_clk &rm_io17_spi1_miso &rm_io16_spi1_mosi &rm_io14_spi1_csn0>;
+
+	spi@0 {
+		compatible = "rockchip,spidev";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+};

--- a/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-zero-w-spi1-2cs-spidev.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-zero-w-spi1-2cs-spidev.dts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Enable spidev on SPI1 with explicit RM_IO pinmux:
+ * MOSI = RM_IO16, MISO = RM_IO17, CLK = RM_IO18, CS0 = RM_IO14, CS1 = RM_IO3
+ * Compatible with Raspberry Pi 'spi1-2cs' hats
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SPI1 spidev on luckfox-lyra-zero-w with two chipselects";
+		compatible = "rockchip,rk3506b-lyra-zero";
+		category = "spi";
+		exclusive = "spi1", "RM_IO3", "RM_IO14", "RM_IO16", "RM_IO17", "RM_IO18";
+		description = "Enable SPI1 spidev using RM_IO16(MOSI), RM_IO17(MISO), RM_IO18(CLK), RM_IO14(CS0), RM_IO3(CS1).";
+	};
+};
+
+&spi1 {
+	status = "okay";
+	num-cs = <2>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&rm_io18_spi1_clk &rm_io17_spi1_miso &rm_io16_spi1_mosi &rm_io14_spi1_csn0 &rm_io3_spi1_csn1>;
+
+	spi@0 {
+		compatible = "rockchip,spidev";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+
+	spi@1 {
+		compatible = "rockchip,spidev";
+		reg = <1>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+};

--- a/arch/arm/boot/dts/rk3506b-luckfox-lyra-ultra-w.dts
+++ b/arch/arm/boot/dts/rk3506b-luckfox-lyra-ultra-w.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Luckfox Lyra Ultra W";
-	compatible = "rockchip,rk3506g-demo-display-control", "rockchip,rk3506";
+	compatible = "rockchip,rk3506b-lyra-ultra", "rockchip,rk3506g-demo-display-control", "rockchip,rk3506";
 
 	//acodec_sound: acodec-sound {
 	//	compatible = "simple-audio-card";

--- a/arch/arm/boot/dts/rk3506b-luckfox-lyra-zero-w-sd.dts
+++ b/arch/arm/boot/dts/rk3506b-luckfox-lyra-zero-w-sd.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Luckfox Lyra Zero W";
-	compatible = "rockchip,rk3506g-demo-display-control", "rockchip,rk3506";
+	compatible = "rockchip,rk3506b-lyra-zero", "rockchip,rk3506g-demo-display-control", "rockchip,rk3506";
 
 	wireless_bluetooth: wireless-bluetooth {
 		compatible = "bluetooth-platdata";

--- a/arch/arm/boot/dts/rk3506g-luckfox-lyra-plus-sd.dts
+++ b/arch/arm/boot/dts/rk3506g-luckfox-lyra-plus-sd.dts
@@ -9,7 +9,7 @@
 
 / {
 	model = "Luckfox Lyra Plus";
-	compatible = "rockchip,rk3506g-demo-display-control", "rockchip,rk3506";
+	compatible = "rockchip,rk3506g-lyra-plus", "rockchip,rk3506g-demo-display-control", "rockchip,rk3506";
 };
 
 /**********display**********/

--- a/arch/arm/boot/dts/rk3506j-forlinx-OK3506-S12.dtsi
+++ b/arch/arm/boot/dts/rk3506j-forlinx-OK3506-S12.dtsi
@@ -202,24 +202,24 @@
 };
 
 &spi0 {
-	status = "okay";
+	status = "disabled";
 
 	spi@0 {
 		compatible = "rockchip,spidev";
 		spi-max-frequency = <50000000>;
 		reg = <0>;
-		status = "okay";
+		status = "disabled";
 	};
 };
 
 &spi1 {
-	status = "okay";
+	status = "disabled";
 
 	spi@0 {
 		compatible = "rockchip,spidev";
 		spi-max-frequency = <50000000>;
 		reg = <0>;
-		status = "okay";
+		status = "disabled";
 	};
 };
 


### PR DESCRIPTION
Adds new devicetree overlays for enabling spidev in a number of configurations of RK3506: ForLinx OK3506-S12, Luckfox Lyra Plus, Lyra Ultra, and Lyra Zero (Pi-like Header).
Establishes a new `metadata.exclusive` paradigm: `RM_IOx`. Overlays with conflicting RMIO pin assignments should not be applied at the same time.
Also refines `compatible` tags for luckfox lyra base DTS's -- maybe someday `armbian-config` will consume/compare these? :pray: 

**Important Note:**
RK3506 uses Rockchip's new "RMIO" (remappable IO); Each vendor (or the end user) is free to assign their SPI/I2C/UART/etc pins wherever they choose. As as a result devicetree overlays for RK3506 are *largely* going to be board-specific.

All overlays have been tested with their respective boards.

Depends on:
- https://github.com/armbian/build/pull/9436