### PR TITLE
arch: arm: dts: add Luckfox Lyra

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -1242,6 +1242,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
 	rk3506g-evb1-v10-sii9022-bt1120-to-hdmi.dtb \
 	rk3506g-evb1-v10-sii9022-rgb2hdmi.dtb \
 	rk3506g-evb2-v10.dtb \
+	rk3506g-luckfox-lyra-sd.dtb \
 	rk3506g-luckfox-lyra-plus-sd.dtb \
 	rk3506g-iotest-v10.dtb \
 	rk3506g-iotest-v10-pdm.dtb \

--- a/arch/arm/boot/dts/rk3506g-luckfox-lyra-sd.dts
+++ b/arch/arm/boot/dts/rk3506g-luckfox-lyra-sd.dts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2024 Rockchip Electronics Co., Ltd.
+ */
+
+/dts-v1/;
+
+#include "rk3506-luckfox-lyra.dtsi"
+
+/ {
+	model = "Luckfox Lyra";
+	compatible = "rockchip,rk3506g-demo-display-control", "rockchip,rk3506";
+};
+
+/**********display**********/
+&cma {
+	size = <0x200000>;
+};
+
+&dsi {
+	status = "okay";
+};
+
+&dsi_dphy {
+	status = "okay";
+};
+
+&dsi_in_vop {
+	status = "okay";
+};
+
+&route_dsi {
+	status = "okay";
+};
+
+/**********ethernet**********/
+&gmac1 {
+	status = "disabled";
+};
+
+&mdio1 {
+	status = "disabled";
+};
+
+/**********usb**********/
+&usb20_otg0 {
+	dr_mode = "host";
+	status = "okay";
+};
+
+&usb20_otg1 {
+	dr_mode = "host";
+	status = "okay";
+};


### PR DESCRIPTION
This adds support for the regular Luckfox Lyra board, it boots and runs fine. See the build PR https://github.com/armbian/build/pull/9630 for more details.

I don't have a way to test the spi changes in https://github.com/armbian/linux-rockchip/pull/450 so unlike the already supported Plus board this one doesn't have spi enabled.