### PR TITLE
luckfox-lyra-zero-w: Default to onboard wifi antenna, add ipex overlay

### DIFF
--- a/arch/arm/boot/dts/overlay/Makefile
+++ b/arch/arm/boot/dts/overlay/Makefile
@@ -8,6 +8,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-luckfox-lyra-plus-spi0-1cs-spidev.dtbo \
 	rockchip-luckfox-lyra-plus-spi0-2cs-spidev.dtbo \
 	rockchip-luckfox-lyra-ultra-w-spi0-1cs-spidev.dtbo \
+	rockchip-luckfox-lyra-zero-w-ipex-antenna.dtbo \
 	rockchip-luckfox-lyra-zero-w-spi0-1cs-spidev.dtbo \
 	rockchip-luckfox-lyra-zero-w-spi0-2cs-spidev.dtbo \
 	rockchip-luckfox-lyra-zero-w-spi1-1cs-spidev.dtbo \

--- a/arch/arm/boot/dts/overlay/README.rockchip-overlays
+++ b/arch/arm/boot/dts/overlay/README.rockchip-overlays
@@ -28,6 +28,7 @@ for Luckfox Lyra Ultra W:
 - spi0-1cs-spidev
 
 for Luckfox Lyra Zero W:
+- ipex-antenna
 - spi0-1cs-spidev
 - spi0-2cs-spidev
 - spi1-1cs-spidev
@@ -72,6 +73,9 @@ Retains pin-compatibility with Luckfox Pico Plus.
 ### luckfox-lyra-ultra-w-spi0-1cs-spidev
 Enables SPI0 spidev on luckfox-lyra-ultra-w with one chipselect.
 Retains pin-compatibility with Luckfox Pico Ultra.
+
+### luckfox-lyra-zero-w-ipex-antenna
+Switches wifi/bluetooth from the onboard antenna to the external IPEX connector.
 
 ### luckfox-lyra-zero-w-spi0-1cs-spidev
 Enables SPI0 spidev on luckfox-lyra-zero-w with one chipselect.

--- a/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-zero-w-ipex-antenna.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-zero-w-ipex-antenna.dts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Switch wifi/bluetooth antenna from onboard to external IPEX connector
+ * on Luckfox Lyra Zero W.
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable IPEX antenna on luckfox-lyra-zero-w";
+		compatible = "rockchip,rk3506b-lyra-zero";
+		category = "misc";
+		description = "Switch wifi/bluetooth from onboard antenna to external IPEX connector (GPIO1_C7 low).";
+	};
+};
+
+&gpio1 {
+	ant-sel-hog {
+		output-low;
+	};
+};

--- a/arch/arm/boot/dts/rk3506b-luckfox-lyra-zero-w-sd.dts
+++ b/arch/arm/boot/dts/rk3506b-luckfox-lyra-zero-w-sd.dts
@@ -99,6 +99,21 @@
 	status = "okay";
 };
 
+/**********gpio**********/
+&gpio1 {
+	/*
+	 * Antenna selection GPIO
+	 * output-high = Onboard antenna selected
+	 * output-low = External (ipex) antenna selected
+	 */
+	ant-sel-hog {
+		gpio-hog;
+		gpios = <RK_PC7 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "ant-sel";
+	};
+};
+
 /**********pinctrl**********/
 &pinctrl {
 	lcd {


### PR DESCRIPTION
Currently the luckfox-lyra-zero-w defaults to using the ipex connector for wifi (not the onboard antenna). This has lead to user confusion.

Use a gpio hog to set the antenna selection pin HIGH, selecting the onboard by default.
Add an overlay for switching to the ipex connector.

Changes have been tested with `luckfox-lyra-zero-w` trixie.