### PR TITLE
libbpf: fix const correctness in resolve_full_path for gcc15

### DIFF
--- a/tools/lib/bpf/libbpf.c
+++ b/tools/lib/bpf/libbpf.c
@@ -10738,7 +10738,7 @@ static int resolve_full_path(const char *file, char *result, size_t result_sz)
 		if (!search_paths[i])
 			continue;
 		for (s = search_paths[i]; s != NULL; s = strchr(s, ':')) {
-			char *next_path;
+			const char *next_path;
 			int seg_len;
 
 			if (s[0] == ':')


### PR DESCRIPTION
`vendor` header compilation fails when building with `resolute` as target. This is likely due to gcc15 being default in Resolute. I threw this at llm and this seem to fix the compilation. 
This was originally discovered because aic8800 compilation failed due to failing headers.
This also looks quite similar to the mainline upstream fix: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=v6.18.24&id=ab21cf885fb2af179c44d8beeabd716133b9385d