### PR TITLE
ptrace: backport upstream fix for CVE-2026-46333 (ssh-keysign-pwn)

### DIFF
--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -912,6 +912,9 @@ struct task_struct {
 	 */
 	unsigned			sched_remote_wakeup:1;
 
+	/* Save user-dumpable when mm goes away */
+	unsigned			user_dumpable:1;
+
 	/* Bit to tell LSMs we're in execve(): */
 	unsigned			in_execve:1;
 	unsigned			in_iowait:1;

--- a/kernel/exit.c
+++ b/kernel/exit.c
@@ -555,6 +555,7 @@ static void exit_mm(void)
 	 */
 	smp_mb__after_spinlock();
 	local_irq_disable();
+	current->user_dumpable = (get_dumpable(mm) == SUID_DUMP_USER);
 	current->mm = NULL;
 	membarrier_update_current_mm(NULL);
 	enter_lazy_tlb(mm, current);

--- a/kernel/ptrace.c
+++ b/kernel/ptrace.c
@@ -282,11 +282,24 @@ static bool ptrace_has_cap(struct user_namespace *ns, unsigned int mode)
 	return ns_capable(ns, CAP_SYS_PTRACE);
 }
 
+static bool task_still_dumpable(struct task_struct *task, unsigned int mode)
+{
+	struct mm_struct *mm = task->mm;
+	if (mm) {
+		if (get_dumpable(mm) == SUID_DUMP_USER)
+			return true;
+		return ptrace_has_cap(mm->user_ns, mode);
+	}
+
+	if (task->user_dumpable)
+		return true;
+	return ptrace_has_cap(&init_user_ns, mode);
+}
+
 /* Returns 0 on success, -errno on denial. */
 static int __ptrace_may_access(struct task_struct *task, unsigned int mode)
 {
 	const struct cred *cred = current_cred(), *tcred;
-	struct mm_struct *mm;
 	kuid_t caller_uid;
 	kgid_t caller_gid;
 
@@ -347,11 +360,8 @@ ok:
 	 * Pairs with a write barrier in commit_creds().
 	 */
 	smp_rmb();
-	mm = task->mm;
-	if (mm &&
-	    ((get_dumpable(mm) != SUID_DUMP_USER) &&
-	     !ptrace_has_cap(mm->user_ns, mode)))
-	    return -EPERM;
+	if (!task_still_dumpable(task, mode))
+		return -EPERM;
 
 	return security_ptrace_access_check(task, mode);
 }


### PR DESCRIPTION
## Summary

Backports mainline commit [`31e62c2ebbfd`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=31e62c2ebbfdc3fe3dbdf5e02c92a9dc67087a3a) (Linus Torvalds, 2026-05-13) to `rk-6.1-rkr5.1`, closing the `__ptrace_may_access()` logic flaw that lets an unprivileged local user race `ssh-keysign`'s exit and steal SSH host private keys / `/etc/shadow` FDs via `pidfd_getfd()`.

Closes #480.

## Changes
- `include/linux/sched.h`: add `task_struct.user_dumpable:1` bitfield
- `kernel/exit.c`: cache dumpability in `exit_mm()` before clearing `mm`
- `kernel/ptrace.c`: new `task_still_dumpable()` helper; `__ptrace_may_access()` now requires `CAP_SYS_PTRACE` on the no-mm path

Context-only adaptation vs mainline: `sched.h` hunk rewritten for pre-6.7 (no `sched_rt_mutex` bitfield, LSM comment wording).