### PR TITLE
arm64: dts: rockchip: fix adc-keys press-threshold-microvolt for recomputer devkits

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3576-recomputer-rk3576-devkit.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3576-recomputer-rk3576-devkit.dts
@@ -34,7 +34,7 @@
 		volumeup-key {
 			linux,code = <KEY_VOLUMEUP>;
 			label = "volume up";
-			press-threshold-microvolt = <1750>;
+			press-threshold-microvolt = <1750000>;
 		};
 	};
 

--- a/arch/arm64/boot/dts/rockchip/rk3588-recomputer-rk3588-devkit.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-recomputer-rk3588-devkit.dts
@@ -37,7 +37,7 @@
 		volumeup-key {
 			linux,code = <KEY_VOLUMEUP>;
 			label = "volume up";
-			press-threshold-microvolt = <1750>;
+			press-threshold-microvolt = <1750000>;
 		};
 	};
 


### PR DESCRIPTION
## Summary
- Fix volumeup-key `press-threshold-microvolt` value from 1750 to 1750000 (1.75V) for recomputer rk3576 and rk3588 devkit boards
- The original value was off by a factor of 1000, causing the ADC key detection to malfunction

## Test plan
- [ ] Verify adc-keys node reports correct voltage threshold in sysfs
- [ ] Test volume up key functionality on recomputer rk3576-devkit
- [ ] Test volume up key functionality on recomputer rk3588-devkit