### PR TITLE
arm64: dts: rockchip: rk3576: remove empty rockchip,supported-hw from OPP tables

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
@@ -398,7 +398,6 @@
 
 		nvmem-cells = <&cpul_leakage>, <&cpul_opp_info>, <&specification_serial_number>;
 		nvmem-cell-names = "leakage", "opp-info", "specification_serial_number";
-		rockchip,supported-hw;
 
 		rockchip,pvtm-hw = <0x06>;
 		rockchip,pvtm-voltage-sel-hw = <
@@ -662,7 +661,6 @@
 
 		nvmem-cells = <&cpub_leakage>, <&cpub_opp_info>, <&specification_serial_number>;
 		nvmem-cell-names = "leakage", "opp-info", "specification_serial_number";
-		rockchip,supported-hw;
 
 		rockchip,pvtm-hw = <0x06>;
 		rockchip,pvtm-voltage-sel-hw = <
@@ -951,7 +949,6 @@
 
 		nvmem-cells = <&log_leakage>, <&specification_serial_number>;
 		nvmem-cell-names = "leakage", "specification_serial_number";
-		rockchip,supported-hw;
 
 		rockchip,leakage-voltage-sel = <
 			1	10	0
@@ -1184,7 +1181,6 @@
 
 		nvmem-cells = <&log_leakage>, <&logic_opp_info>, <&specification_serial_number>;
 		nvmem-cell-names = "leakage", "opp-info", "specification_serial_number";
-		rockchip,supported-hw;
 
 		rockchip,early-min-microvolt = <0 750000>; /* <vdd_ddr vdd_logic> */
 
@@ -2443,7 +2439,6 @@
 
 		nvmem-cells = <&npu_leakage>, <&npu_opp_info>, <&specification_serial_number>;
 		nvmem-cell-names = "leakage", "opp-info", "specification_serial_number";
-		rockchip,supported-hw;
 
 		rockchip,pvtm-hw = <0x06>;
 		rockchip,pvtm-voltage-sel-hw = <
@@ -2689,7 +2684,6 @@
 
 		nvmem-cells = <&gpu_leakage>, <&gpu_opp_info>, <&specification_serial_number>;
 		nvmem-cell-names = "leakage", "opp-info", "specification_serial_number";
-		rockchip,supported-hw;
 
 		rockchip,pvtm-hw = <0x06>;
 		rockchip,pvtm-voltage-sel-hw = <
@@ -3527,7 +3521,6 @@
 
 		nvmem-cells = <&log_leakage>, <&specification_serial_number>;
 		nvmem-cell-names = "leakage", "specification_serial_number";
-		rockchip,supported-hw;
 
 		rockchip,early-min-microvolt = <750000>; /* vdd_logic */
 

--- a/arch/arm64/boot/dts/rockchip/rk3576.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3576.dtsi
@@ -398,6 +398,7 @@
 
 		nvmem-cells = <&cpul_leakage>, <&cpul_opp_info>, <&specification_serial_number>;
 		nvmem-cell-names = "leakage", "opp-info", "specification_serial_number";
+		rockchip,supported-hw;
 
 		rockchip,pvtm-hw = <0x06>;
 		rockchip,pvtm-voltage-sel-hw = <
@@ -661,6 +662,7 @@
 
 		nvmem-cells = <&cpub_leakage>, <&cpub_opp_info>, <&specification_serial_number>;
 		nvmem-cell-names = "leakage", "opp-info", "specification_serial_number";
+		rockchip,supported-hw;
 
 		rockchip,pvtm-hw = <0x06>;
 		rockchip,pvtm-voltage-sel-hw = <
@@ -949,6 +951,7 @@
 
 		nvmem-cells = <&log_leakage>, <&specification_serial_number>;
 		nvmem-cell-names = "leakage", "specification_serial_number";
+		rockchip,supported-hw;
 
 		rockchip,leakage-voltage-sel = <
 			1	10	0
@@ -1181,6 +1184,7 @@
 
 		nvmem-cells = <&log_leakage>, <&logic_opp_info>, <&specification_serial_number>;
 		nvmem-cell-names = "leakage", "opp-info", "specification_serial_number";
+		rockchip,supported-hw;
 
 		rockchip,early-min-microvolt = <0 750000>; /* <vdd_ddr vdd_logic> */
 
@@ -2439,6 +2443,7 @@
 
 		nvmem-cells = <&npu_leakage>, <&npu_opp_info>, <&specification_serial_number>;
 		nvmem-cell-names = "leakage", "opp-info", "specification_serial_number";
+		rockchip,supported-hw;
 
 		rockchip,pvtm-hw = <0x06>;
 		rockchip,pvtm-voltage-sel-hw = <
@@ -3521,6 +3526,7 @@
 
 		nvmem-cells = <&log_leakage>, <&specification_serial_number>;
 		nvmem-cell-names = "leakage", "specification_serial_number";
+		rockchip,supported-hw;
 
 		rockchip,early-min-microvolt = <750000>; /* vdd_logic */
 


### PR DESCRIPTION
## Summary
- Remove empty `rockchip,supported-hw;` property from 7 OPP tables in rk3576.dtsi (cluster0, cluster1, bus_a72, dmc, npu, gpu, vop)
- The bare property with no value makes the OPP framework require `opp-supported-hw` on every OPP entry, but only `opp-j-m-*` entries have it. This causes all generic OPP entries to be rejected, resulting in GPU stuck at ~100 MHz without devfreq

## Test plan
- [ ] Verify GPU devfreq scales properly on rk3576 (non-J/M variant)
- [ ] Check CPU frequency scaling works on cluster0/cluster1
- [ ] Verify no regression on J/M variants that use opp-supported-hw entries