### PR TITLE
arm: dts: add Vanxoak HD-RK3506G-EVB board support

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -1246,6 +1246,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
 	rk3506g-iotest-v10.dtb \
 	rk3506g-iotest-v10-pdm.dtb \
 	rk3506g-test1-v10-audio.dtb \
+	rk3506g-vanxoak-hd-rk3506g-evb.dtb \
 	rk3506j-forlinx-OK3506-S12_nand-microsd.dtb \
 	rk3528-demo4-ddr4-v10.dtb \
 	rk3528-evb1-ddr4-v10.dtb \

--- a/arch/arm/boot/dts/overlay/Makefile
+++ b/arch/arm/boot/dts/overlay/Makefile
@@ -17,7 +17,8 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-luckfox-lyra-zero-w-spi1-1cs-spidev.dtbo \
 	rockchip-luckfox-lyra-zero-w-spi1-2cs-spidev.dtbo \
 	rockchip-rk3506-disable-ethernet0.dtbo \
-	rockchip-rk3506-disable-ethernet1.dtbo
+	rockchip-rk3506-disable-ethernet1.dtbo \
+	rockchip-vanxoak-hd-rk3506g-evb-all-opp.dtbo
 
 dtbotxt-$(CONFIG_ARCH_ROCKCHIP) += \
 	README.rockchip-overlays

--- a/arch/arm/boot/dts/overlay/rockchip-vanxoak-hd-rk3506g-evb-all-opp.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-vanxoak-hd-rk3506g-evb-all-opp.dts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable all CPU OPPs";
+		compatible = "vanxoak,hd-rk3506g-evb", "rockchip,rk3506";
+		category = "misc";
+		description = "Fake vdd_arm LDO to 1100mV to activate all CPU OPPs.";
+	};
+};
+
+&vdd_arm {
+	regulator-min-microvolt = <1100000>;
+	regulator-max-microvolt = <1100000>;
+};

--- a/arch/arm/boot/dts/rk3506g-vanxoak-hd-rk3506g-evb.dts
+++ b/arch/arm/boot/dts/rk3506g-vanxoak-hd-rk3506g-evb.dts
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2024 Rockchip Electronics Co., Ltd.
+ * Vanxoak HD-RK3506G-EVB V1 Board
+ */
+
+/dts-v1/;
+
+#include "rk3506.dtsi"
+
+/ {
+	model = "Vanxoak HD-RK3506G-EVB V1 Board";
+	compatible = "vanxoak,hd-rk3506g-evb", "rockchip,rk3506";
+
+	chosen {
+		bootargs = "earlycon=uart8250,mmio32,0xff0a0000 console=ttyFIQ0";
+	};
+
+	fiq_debugger: fiq-debugger {
+		compatible = "rockchip,fiq-debugger";
+		rockchip,serial-id = <0>;
+		rockchip,wake-irq = <0>;
+		rockchip,irq-mode-enable = <1>;
+		rockchip,baudrate = <1500000>;
+		interrupts = <GIC_SPI 115 IRQ_TYPE_LEVEL_HIGH>;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		status = "okay";
+
+		heart_led {
+			label = "run";
+			gpios = <&gpio0 RK_PD0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	vcc_sys: vcc-sys {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_sys";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+	};
+
+	vcc3v3_stb: vcc3v3-stb {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc3v3_stb";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&vcc_sys>;
+	};
+
+	vcc_1v8: vcc-1v8 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_1v8";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		vin-supply = <&vcc3v3_stb>;
+	};
+
+	vdd_arm: vdd-arm {
+		compatible = "regulator-fixed";
+		regulator-name = "vdd_arm";
+		regulator-min-microvolt = <960000>;
+		regulator-max-microvolt = <960000>;
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&vcc_sys>;
+	};
+
+	vcc_ddr: vcc-ddr {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_ddr";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&vcc_sys>;
+	};
+};
+
+&cpu0 {
+	cpu-supply = <&vdd_arm>;
+};
+
+&fspi {
+	status = "okay";
+
+	flash@0 {
+		compatible = "spi-nand";
+		reg = <0>;
+		spi-max-frequency = <80000000>;
+		spi-rx-bus-width = <4>;
+		spi-tx-bus-width = <1>;
+	};
+};
+
+&mmc {
+	max-frequency = <150000000>;
+	supports-sd;
+	bus-width = <4>;
+	cd-gpios = <&gpio1 RK_PB3 GPIO_ACTIVE_LOW>;
+	cap-sd-highspeed;
+	disable-wp;
+	vmmc-supply = <&vcc3v3_stb>;
+	vqmmc-supply = <&vcc3v3_stb>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&sdmmc_clk_pins &sdmmc_cmd_pins &sdmmc_bus4_pins>;
+	status = "okay";
+};
+
+&gmac0 {
+	phy-mode = "rmii";
+	clock_in_out = "input";
+	snps,reset-gpio = <&gpio1 RK_PD3 GPIO_ACTIVE_LOW>;
+	snps,reset-active-low;
+	snps,reset-delays-us = <0 20000 100000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_rmii0_miim_pins
+		     &eth_rmii0_tx_bus2_pins
+		     &eth_rmii0_rx_bus2_pins
+		     &eth_rmii0_clk_pins>;
+	phy-handle = <&rmii_phy0>;
+	status = "okay";
+};
+
+&gmac1 {
+	phy-mode = "rmii";
+	clock_in_out = "input";
+	snps,reset-gpio = <&gpio1 RK_PD2 GPIO_ACTIVE_LOW>;
+	snps,reset-active-low;
+	snps,reset-delays-us = <0 20000 100000>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth_rmii1_miim_pins
+		     &eth_rmii1_tx_bus2_pins
+		     &eth_rmii1_rx_bus2_pins
+		     &eth_rmii1_clk_pins>;
+	phy-handle = <&rmii_phy1>;
+	status = "okay";
+};
+
+&mdio0 {
+	rmii_phy0: phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0x0>;
+		clocks = <&cru CLK_MAC_OUT>;
+		assigned-clocks = <&cru CLK_MAC_OUT>;
+		assigned-clock-rates = <25000000>;
+	};
+};
+
+&mdio1 {
+	rmii_phy1: phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0x0>;
+		clocks = <&cru CLK_MAC_OUT>;
+		assigned-clocks = <&cru CLK_MAC_OUT>;
+		assigned-clock-rates = <25000000>;
+	};
+};
+
+&rng {
+	status = "okay";
+};
+
+&saradc {
+	vref-supply = <&vcc_1v8>;
+	status = "okay";
+};
+
+&tsadc {
+	status = "okay";
+};
+
+&usb2phy {
+	status = "okay";
+};
+
+&u2phy_otg0 {
+	status = "okay";
+};
+
+&u2phy_otg1 {
+	status = "okay";
+};
+
+&usb20_otg0 {
+	dr_mode = "peripheral";
+	status = "okay";
+};
+
+&usb20_otg1 {
+	dr_mode = "host";
+	status = "okay";
+};


### PR DESCRIPTION
Add device tree for the Vanxoak HD-RK3506G-EVB V1 board featuring:
- Dual RMII Ethernet (GMAC0/GMAC1, clock_in_out=input, 25MHz CLK_MAC_OUT)
- SPI-NAND via FSPI
- SD card
- USB OTG0 (peripheral) + OTG1 (host)
- Heartbeat LED with silk layer mark "RUN"
- An device tree overlay that forces enable all opp tables by fake the vdd-arm voltage to 1100mV