### PR TITLE
ASoC: hdmi-codec: restore HDMI-IN capture broken by #430

### DIFF
--- a/include/sound/hdmi-codec.h
+++ b/include/sound/hdmi-codec.h
@@ -125,6 +125,10 @@ struct hdmi_codec_pdata {
 	const struct hdmi_codec_ops *ops;
 	uint i2s:1;
 	uint spdif:1;
+	uint no_i2s_playback:1;
+	uint no_i2s_capture:1;
+	uint no_spdif_playback:1;
+	uint no_spdif_capture:1;
 	int max_i2s_channels;
 	void *data;
 };

--- a/sound/soc/codecs/hdmi-codec.c
+++ b/sound/soc/codecs/hdmi-codec.c
@@ -459,9 +459,14 @@ static int hdmi_codec_startup(struct snd_pcm_substream *substream,
 {
 	struct hdmi_codec_priv *hcp = snd_soc_dai_get_drvdata(dai);
 	bool tx = substream->stream == SNDRV_PCM_STREAM_PLAYBACK;
+	bool has_capture = !hcp->hcd.no_i2s_capture;
+	bool has_playback = !hcp->hcd.no_i2s_playback;
 	int ret = 0;
 
 	if (hcp->tx_dlp && substream->stream != SNDRV_PCM_STREAM_PLAYBACK)
+		return 0;
+
+	if (!((has_playback && tx) || (has_capture && !tx)))
 		return 0;
 
 	mutex_lock(&hcp->lock);
@@ -503,8 +508,14 @@ static void hdmi_codec_shutdown(struct snd_pcm_substream *substream,
 				struct snd_soc_dai *dai)
 {
 	struct hdmi_codec_priv *hcp = snd_soc_dai_get_drvdata(dai);
+	bool tx = substream->stream == SNDRV_PCM_STREAM_PLAYBACK;
+	bool has_capture = !hcp->hcd.no_i2s_capture;
+	bool has_playback = !hcp->hcd.no_i2s_playback;
 
 	if (hcp->tx_dlp && substream->stream != SNDRV_PCM_STREAM_PLAYBACK)
+		return;
+
+	if (!((has_playback && tx) || (has_capture && !tx)))
 		return;
 
 	hcp->chmap_idx = HDMI_CODEC_CHMAP_IDX_UNKNOWN;

--- a/sound/soc/codecs/hdmi-codec.c
+++ b/sound/soc/codecs/hdmi-codec.c
@@ -1110,21 +1110,23 @@ static int hdmi_codec_probe(struct platform_device *pdev)
 	if (hcd->i2s) {
 		daidrv[i] = hdmi_i2s_dai;
 		daidrv[i].playback.channels_max = hcd->max_i2s_channels;
-		/* Disable capture for HDMI-TX (output only) to prevent
-		 * PulseAudio from trying to open capture streams which
-		 * causes "Only one simultaneous stream supported!" errors
-		 * and results in mono audio output.
-		 */
-		daidrv[i].capture.channels_min = 0;
-		daidrv[i].capture.channels_max = 0;
+		if (hcd->no_i2s_playback)
+			memset(&daidrv[i].playback, 0,
+			       sizeof(daidrv[i].playback));
+		if (hcd->no_i2s_capture)
+			memset(&daidrv[i].capture, 0,
+			       sizeof(daidrv[i].capture));
 		i++;
 	}
 
 	if (hcd->spdif) {
 		daidrv[i] = hdmi_spdif_dai;
-		/* Disable capture for HDMI-TX SPDIF (output only) */
-		daidrv[i].capture.channels_min = 0;
-		daidrv[i].capture.channels_max = 0;
+		if (hcd->no_spdif_playback)
+			memset(&daidrv[i].playback, 0,
+			       sizeof(daidrv[i].playback));
+		if (hcd->no_spdif_capture)
+			memset(&daidrv[i].capture, 0,
+			       sizeof(daidrv[i].capture));
 	}
 
 	dev_set_drvdata(dev, hcp);


### PR DESCRIPTION
## Summary

PR #430 fixed mono audio on RK3576 NanoPi HDMI-TX boards by unconditionally zeroing `daidrv[].capture.channels_min/max` in `hdmi_codec_probe()`. However, the same `hdmi-audio-codec` child device is registered by `rk_hdmirx` (HDMI-IN) on every RK3588 board with HDMI input, so the unconditional zeroing also killed the HDMI-IN capture PCM:

- Card 1 appears in `/proc/asound/cards` but has zero capture streams
- Absent from `arecord -l`
- `/proc/asound/pcm` line ends in a bare colon

Bisected on Orange Pi 5 Ultra: `linux-image-vendor-rk35xx` 25.8.2 works, 26.2.1 broken.

Also reported independently on Radxa Rock 5 ITX: https://forum.armbian.com/topic/56884-hdmi-input-audio-not-working-with-the-last-bsp-kernel/

## Changes

**Commit 1** — backport of upstream [`f77a066f4ed3`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f77a066f4ed307db93aafee621e2683c3bda98ce) (Mark Brown):
- Removes the unconditional zeroing of capture channels
- Adds per-instance `no_i2s_playback`, `no_i2s_capture`, `no_spdif_playback`, `no_spdif_capture` flags to `hdmi_codec_pdata`
- TX-only drivers can opt in to disable capture; `rk_hdmirx` leaves flags unset so capture survives

**Commit 2** — backport of upstream [`e041a2a55058`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=e041a2a550582106cba6a7c862c90dfc2ad14492) (Emil Svendsen):
- Makes `hdmi_codec_startup`/`shutdown` silently return 0 for unsupported stream directions
- Prevents "Only one simultaneous stream supported!" errors on multi-codec cards
- Rebased on top of the vendor kernel's `tx_dlp` early-return guard (commit `e22dfe2e`)

## Test plan

- [x] Tested on Orange Pi 5 Ultra (RK3588) with Armbian 26.2.1
- [x] `arecord -l` shows HDMI-IN capture device after patch
- [x] `arecord -D hw:1,0 -f S16_LE -r 48000 -c 2` captures audio from HDMI source
- [x] HDMI-TX playback still works (no regression on output-only path)
- [ ] Verify RK3576 NanoPi boards still get the mono-audio fix (drivers that set `no_i2s_capture = 1` should behave identically to the old zeroing) - I can't do this as I dont have access to rk3576