### PR TITLE
media: rockchip: hdmirx: add DT-driven edid-version + set 600M for OPi5U

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-orangepi-5-ultra.dts
@@ -1400,6 +1400,7 @@
 /* Should work with at least 128MB cma reserved above. */
 &hdmirx_ctrler {
 	#sound-dai-cells = <1>;
+	edid-version = <2>;
 	/* Effective level used to trigger HPD: 0-low, 1-high */
 	hpd-trigger-level = <1>;
 	hdmirx-det-gpios = <&gpio3 RK_PD3 GPIO_ACTIVE_LOW>;

--- a/drivers/media/platform/rockchip/hdmirx/rk_hdmirx.c
+++ b/drivers/media/platform/rockchip/hdmirx/rk_hdmirx.c
@@ -148,6 +148,8 @@ enum hdmirx_edid_version {
 	HDMIRX_EDID_USER = 0,
 	HDMIRX_EDID_340M = 1,
 	HDMIRX_EDID_600M = 2,
+	HDMIRX_EDID_340M_NV12 = 3,
+	HDMIRX_EDID_600M_NV12 = 4,
 };
 
 struct hdmirx_reg_table {
@@ -4003,7 +4005,6 @@ static int hdmirx_parse_dt(struct rk_hdmirx_dev *hdmirx_dev)
 		return PTR_ERR(hdmirx_dev->rst_biu);
 	}
 
-
 	hdmirx_dev->hdmirx_det_gpio = devm_gpiod_get_optional(dev,
 			"hdmirx-det", GPIOD_IN);
 	if (IS_ERR(hdmirx_dev->hdmirx_det_gpio)) {
@@ -4038,6 +4039,8 @@ static int hdmirx_parse_dt(struct rk_hdmirx_dev *hdmirx_dev)
 
 	if (of_property_read_bool(np, "cec-enable"))
 		hdmirx_dev->cec_enable = true;
+
+	of_property_read_u32(np, "edid-version", &hdmirx_dev->edid_version);
 
 	ret = of_reserved_mem_device_init(dev);
 	if (ret)
@@ -4098,19 +4101,51 @@ static int hdmirx_power_on(struct rk_hdmirx_dev *hdmirx_dev)
 	return 0;
 }
 
+static void hdmirx_fixup_edid(struct rk_hdmirx_dev *hdmirx_dev,
+			      u8 *edid, int edid_len)
+{
+	int i;
+	u8 sum;
+
+	/* CTA Extension data format */
+#define EDID_CEA_YCRCB444	(1 << 5)
+
+	if (hdmirx_dev->edid_version == HDMIRX_EDID_340M ||
+	    hdmirx_dev->edid_version == HDMIRX_EDID_600M)
+		edid[131] |=  EDID_CEA_YCRCB444;
+	else
+		edid[131] &= ~EDID_CEA_YCRCB444;
+
+	/* update checksum */
+	for (i = 0, sum = 0; i < edid_len - 1; i++)
+		sum += edid[i];
+
+	edid[i] = 0x100 - sum;
+}
+
 static void hdmirx_edid_init_config(struct rk_hdmirx_dev *hdmirx_dev)
 {
 	int ret;
 	struct v4l2_edid def_edid;
+	u8 *edid_data;
+	int edid_len;
 
 	/* disable hpd and write edid */
 	def_edid.pad = 0;
 	def_edid.start_block = 0;
 	def_edid.blocks = EDID_NUM_BLOCKS_MAX;
-	if (hdmirx_dev->edid_version == HDMIRX_EDID_600M)
-		def_edid.edid = edid_init_data_600M;
-	else
-		def_edid.edid = edid_init_data_340M;
+
+	if (hdmirx_dev->edid_version == HDMIRX_EDID_600M ||
+	    hdmirx_dev->edid_version == HDMIRX_EDID_600M_NV12) {
+		edid_data = edid_init_data_600M;
+		edid_len = sizeof(edid_init_data_600M);
+	} else {
+		edid_data = edid_init_data_340M;
+		edid_len = sizeof(edid_init_data_340M);
+	}
+	hdmirx_fixup_edid(hdmirx_dev, edid_data, edid_len);
+
+	def_edid.edid = edid_data;
 	ret = hdmirx_write_edid(hdmirx_dev, &def_edid, false);
 	if (ret)
 		dev_err(hdmirx_dev->dev, "%s write edid failed!\n", __func__);
@@ -4244,7 +4279,8 @@ static ssize_t edid_store(struct device *dev,
 	if (kstrtoint(buf, 10, &edid))
 		return -EINVAL;
 
-	if (edid != HDMIRX_EDID_340M && edid != HDMIRX_EDID_600M)
+	if (edid != HDMIRX_EDID_340M && edid != HDMIRX_EDID_340M_NV12 &&
+	    edid != HDMIRX_EDID_600M && edid != HDMIRX_EDID_600M_NV12)
 		return count;
 
 	if (hdmirx_dev->edid_version != edid) {


### PR DESCRIPTION
## Summary

On Orange Pi 5 Ultra, the hdmirx driver defaults to a 340 MHz EDID which only advertises up to 1080p60 / 4K@30. A 4K-capable HDMI source pushing 3840x2160@60 cycles indefinitely between TMDS-valid and TMDS-invalid states because the EDID doesn't advertise 4K@60 support while the source insists on 4K.

Writing `2` to `/sys/devices/platform/fdee0000.hdmirx-controller/hdmirx/hdmirx/edid` at runtime resolves it, but this needs to be the default at boot.

## Changes

**Commit 1** — cherry-pick of FriendlyElec commit [`ee391fb2`](https://github.com/friendlyarm/kernel-rockchip/commit/ee391fb229f90af6866cba9e514fd96676dbf843) by jensen (jensenhuang@friendlyarm.com) from `nanopi6-v6.1.y`:
- Adds two new EDID variants (`HDMIRX_EDID_340M_NV12 = 3`, `HDMIRX_EDID_600M_NV12 = 4`) that omit YCbCr 4:4:4 (NV24) capability
- Adds `hdmirx_fixup_edid()` to toggle `EDID_CEA_YCRCB444` and recalculate checksums
- Reads `edid-version` from device tree so per-board defaults can be set without runtime sysfs writes
- Rock 5B+ and NanoPC-T6 already use similar properties in their DTS files

**Commit 2** — new DTS property for Orange Pi 5 Ultra:
- Sets `edid-version = <2>` (HDMIRX_EDID_600M) on the `hdmirx_ctrler` node
- Advertises TMDS up to 600 MHz, covering 4K@60 modes

## Test plan

- [x] Tested on Orange Pi 5 Ultra (RK3588) with Armbian 26.2.1
- [x] 4K@60 HDMI source (Linux desktop, discrete GPU) locks stably on first plug
- [x] 1080p60 HDMI source still works (backward compatible)
- [x] `v4l2-ctl --query-dv-timings` reports correct 3840x2160p59.94 timings
- [x] No TMDS cycling observed over 24h continuous capture