### PR TITLE
arm64: dts: rockchip: add vpll clock parent for DP 4K overlay

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/recomputer-rk3576-devkit-dp-4k.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/recomputer-rk3576-devkit-dp-4k.dts
@@ -1,12 +1,14 @@
 /dts-v1/;
 /plugin/;
 
+#include <dt-bindings/clock/rockchip,rk3576-cru.h>
+
 / {
 	metadata {
 		title = "Route recomputer rk3576 devkit HDMI to VP1 and DP to VP0";
 		compatible = "seeed,recomputer rk3576 devkit";
 		category = "display";
-		description = "Switch display routing so HDMI uses VP1 and DP uses VP0.";
+		description = "Switch display routing so HDMI uses VP1 and DP uses VP0. Sets dclk_vp0_src parent to vpll for 4K@60Hz pixel clock support.";
 	};
 
 	fragment@0 {
@@ -68,5 +70,18 @@
 	fragment@10 {
 		target = <&vp1>;
 		__overlay__ { status = "okay"; };
+	};
+
+	/* Set dclk_vp0_src parent to vpll so DP on VP0 can achieve 4K@60Hz.
+	 * Without this, DP falls back to gpll/cpll which can only provide
+	 * ~396MHz (via divider), far below the 533.25MHz needed for 4K@60Hz.
+	 * With vpll, the driver reprograms vpll to 1066.5MHz and divides by 2.
+	 */
+	fragment@11 {
+		target = <&vop>;
+		__overlay__ {
+			assigned-clocks = <&cru DCLK_VP0_SRC>;
+			assigned-clock-parents = <&cru PLL_VPLL>;
+		};
 	};
 };


### PR DESCRIPTION
## Summary

- Set `dclk_vp0_src` parent to `vpll` in the recomputer-rk3576-devkit DP 4K overlay, enabling 4K@60Hz pixel clock support when DP is routed to VP0

## Problem

The RK3576 has only one HDMI PHY PLL which is occupied by HDMI when both HDMI and DP are active. When the dp-4k overlay routes DP to VP0, the pixel clock falls back to gpll/cpll which can only provide ~396MHz via divider, far below the 533.25MHz needed for 3840x2160@60Hz.

Before: `set dclk_vp0 to 533250000, get 396000000`
After:  `set dclk_vp0 to 533250000, get 533250000`

## Details

With this change, the VOP2 driver's `rockchip_rk3576_drm_dclk_set_rate()` will reprogram vpll to 1066.5MHz and divide by 2 to get the exact 533.25MHz pixel clock.

## Test plan

- [ ] Verify DP 4K@60Hz output works on reComputer RK3576 Devkit with dp-4k overlay loaded
- [ ] Verify HDMI output is unaffected when DP 4K overlay is not loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)