### PR TITLE
Seeed reComputer: display and Ethernet fixes

### DIFF
--- a/drivers/gpu/drm/rockchip/dw-dp.c
+++ b/drivers/gpu/drm/rockchip/dw-dp.c
@@ -507,6 +507,8 @@ struct dw_dp {
 	struct list_head mst_conn_list;
 	struct rockchip_dp_aux_client *aux_client;
 
+	struct edid *cached_edid;
+
 	struct drm_info_list *debugfs_files;
 	struct typec_mux_dev *mux;
 };
@@ -1461,10 +1463,24 @@ static int dw_dp_connector_get_modes(struct drm_connector *connector)
 	if (!num_modes) {
 		edid = drm_bridge_get_edid(&dp->bridge, connector);
 		if (edid) {
+			kfree(dp->cached_edid);
+			dp->cached_edid = kmemdup(edid,
+					(edid->extensions + 1) * EDID_LENGTH,
+					GFP_KERNEL);
 			drm_connector_update_edid_property(connector, edid);
 			num_modes = drm_add_edid_modes(connector, edid);
 			dw_dp_update_hdr_property(connector);
 			kfree(edid);
+		} else if (dp->cached_edid) {
+			dev_warn(dp->dev, "EDID read failed, using cached EDID\n");
+			edid = kmemdup(dp->cached_edid,
+				       (dp->cached_edid->extensions + 1) * EDID_LENGTH,
+				       GFP_KERNEL);
+			if (edid) {
+				drm_connector_update_edid_property(connector, edid);
+				num_modes = drm_add_edid_modes(connector, edid);
+				kfree(edid);
+			}
 		}
 	}
 
@@ -3121,6 +3137,7 @@ static ssize_t dw_dp_aux_transfer(struct drm_dp_aux *aux,
 	unsigned long timeout = msecs_to_jiffies(10);
 	u32 status, value;
 	ssize_t ret = 0;
+	int retry;
 
 	if (WARN_ON(msg->size > 16))
 		return -E2BIG;
@@ -3150,11 +3167,37 @@ static ssize_t dw_dp_aux_transfer(struct drm_dp_aux *aux,
 		value = FIELD_PREP(I2C_ADDR_ONLY, 1);
 	value |= FIELD_PREP(AUX_CMD_TYPE, msg->request);
 	value |= FIELD_PREP(AUX_ADDR, msg->address);
-	regmap_write(dp->regmap, DPTX_AUX_CMD, value);
+	for (retry = 0; retry < 2; retry++) {
+		reinit_completion(&dp->complete);
+		regmap_write(dp->regmap, DPTX_AUX_CMD, value);
 
-	status = wait_for_completion_timeout(&dp->complete, timeout);
+		status = wait_for_completion_timeout(&dp->complete, timeout);
+		if (status)
+			break;
+
+		/* AUX timeout: reset AUX module and retry. On USB-C
+		 * DP Alt Mode setups the AUX channel gets stuck after
+		 * prolonged main link transmission. Reinitializing the
+		 * completion and resetting the AUX module restores
+		 * native AUX functionality for link training.
+		 */
+		if (retry == 0) {
+			dev_warn(dp->dev, "AUX timeout, resetting (cmd=0x%x addr=0x%x)\n",
+				 msg->request, msg->address);
+			regmap_update_bits(dp->regmap, DPTX_SOFT_RESET_CTRL,
+					   AUX_RESET, AUX_RESET);
+			usleep_range(10, 20);
+			regmap_update_bits(dp->regmap, DPTX_SOFT_RESET_CTRL,
+					   AUX_RESET, 0);
+			usleep_range(100, 200);
+			dw_dp_aux_init(dp);
+		}
+	}
+
 	if (!status) {
-		dev_dbg(dp->dev, "timeout waiting for AUX reply\n");
+		regmap_read(dp->regmap, DPTX_AUX_STATUS, &value);
+		dev_info(dp->dev, "AUX timeout after recovery: cmd=0x%x addr=0x%x size=%d, AUX_STATUS=0x%x\n",
+			 msg->request, msg->address, msg->size, value);
 		ret = -ETIMEDOUT;
 		goto out;
 	}
@@ -4544,6 +4587,8 @@ out:
 		return status;
 	}
 	if (status == connector_status_disconnected) {
+		kfree(dp->cached_edid);
+		dp->cached_edid = NULL;
 		if (dp->is_mst) {
 			dev_info(dp->dev, "MST device may have disappeared\n");
 			dp->is_mst = false;

--- a/drivers/gpu/drm/rockchip/dw-mipi-dsi2-rockchip.c
+++ b/drivers/gpu/drm/rockchip/dw-mipi-dsi2-rockchip.c
@@ -1497,6 +1497,10 @@ static int dw_mipi_dsi2_connector_init(struct dw_mipi_dsi2 *dsi2)
 
 	drm_connector_helper_add(connector,
 				 &dw_mipi_dsi2_connector_helper_funcs);
+
+	if (dsi2->panel)
+		drm_connector_set_orientation_from_panel(connector, dsi2->panel);
+
 	ret = drm_connector_attach_encoder(connector, encoder);
 	if (ret < 0) {
 		DRM_DEV_ERROR(dev, "Failed to attach encoder: %d\n", ret);

--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
+++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
@@ -10226,6 +10226,25 @@ static void vop2_crtc_atomic_enable(struct drm_crtc *crtc, struct drm_atomic_sta
 	ret = vop2_clk_set_parent_extend(vp, vcstate, true);
 	if (ret < 0)
 		goto out;
+
+	/*
+	 * For RK3576 MIPI/DSI output, switch dclk_src parent from vpll
+	 * to cpll. This prevents DP's vpll reprogramming from breaking
+	 * DSI pixel clock when both displays are active.
+	 * cpll at 1000MHz supports 720x1280@60 exactly (1000/12=83.33MHz).
+	 */
+	if (vop2->version == VOP_VERSION_RK3576 &&
+	    (vcstate->output_if & (VOP_OUTPUT_IF_MIPI0 | VOP_OUTPUT_IF_MIPI1))) {
+		struct clk_hw *dclk_hw = __clk_get_hw(vp->dclk);
+		if (dclk_hw) {
+			struct clk_hw *src_hw = clk_hw_get_parent(dclk_hw);
+			if (src_hw) {
+				struct clk *cpll = __clk_lookup("cpll");
+				if (cpll)
+					clk_set_parent(src_hw->clk, cpll);
+			}
+		}
+	}
 	if (dclk)
 		dclk_rate = dclk->rate;
 	else

--- a/drivers/net/ethernet/realtek/r8169_main.c
+++ b/drivers/net/ethernet/realtek/r8169_main.c
@@ -3690,6 +3690,13 @@ static void rtl_hw_start_8125_common(struct rtl8169_private *tp)
 		rtl8125a_config_eee_mac(tp);
 
 	rtl_disable_rxdvgate(tp);
+
+	/* Board-specific LED policy for Seeed boards:
+	 * LED0 (yellow): blink on traffic at all link speeds
+	 * LED3 (green): solid on at all link speeds
+	 */
+	RTL_W16(tp, 0x18, 0x022B);
+	RTL_W16(tp, 0x96, 0x002B);
 }
 
 static void rtl_hw_start_8125a_2(struct rtl8169_private *tp)


### PR DESCRIPTION
## Summary

Board-specific fixes for Seeed reComputer RK3576/RK3588 devkits, extracted from our Armbian extension patches. Referenced in armbian/build#9719.

### Patches

- **drm: rockchip: dw-dp: AUX recovery and EDID cache for USB-C DP Alt Mode** — On RK3576 with USB-C DP Alt Mode, the AUX channel gets stuck after ~15s of active main link transmission. Adds `reinit_completion()` + retry with AUX module reset, and caches EDID to survive I2C-over-AUX failures.
- **drm/rockchip: rk3576: switch DSI dclk_src from vpll to cpll** — When both DP and DSI are active, DP reprograms vpll which breaks DSI. Switch DSI VP's dclk parent to cpll (1000MHz, supports 720x1280@60 exactly).
- **drm/rockchip: dw-mipi-dsi2: set panel orientation before device registration** — Fixes WARNING in `__drm_mode_object_add()` when DSI panel driver calls `drm_connector_set_panel_orientation()` from `get_modes` after DRM device registration.
- **net: r8125 LED policy for Seeed boards** — Sets LED0 (yellow) to blink on traffic at all link speeds, LED3 (green) solid on at all speeds. ⚠️ This modifies `rtl_hw_start_8125_common()` and affects all r8125 users — open to reworking via device tree or module parameter if preferred.

## Testing

All patches tested on reComputer RK3576 DevKit with:
- USB-C DP Alt Mode hotplug / re-plug / display manager restart
- Simultaneous HDMI + DP + DSI output
- DSI panel (ili9881c) with portrait orientation
- r8125 Ethernet LED behavior