### PR TITLE
drm: rockchip: DSI fixes for RK3576 dual-display

### DIFF
--- a/drivers/gpu/drm/rockchip/dw-mipi-dsi2-rockchip.c
+++ b/drivers/gpu/drm/rockchip/dw-mipi-dsi2-rockchip.c
@@ -1497,6 +1497,10 @@ static int dw_mipi_dsi2_connector_init(struct dw_mipi_dsi2 *dsi2)
 
 	drm_connector_helper_add(connector,
 				 &dw_mipi_dsi2_connector_helper_funcs);
+
+	if (dsi2->panel)
+		drm_connector_set_orientation_from_panel(connector, dsi2->panel);
+
 	ret = drm_connector_attach_encoder(connector, encoder);
 	if (ret < 0) {
 		DRM_DEV_ERROR(dev, "Failed to attach encoder: %d\n", ret);

--- a/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
+++ b/drivers/gpu/drm/rockchip/rockchip_drm_vop2.c
@@ -10226,6 +10226,25 @@ static void vop2_crtc_atomic_enable(struct drm_crtc *crtc, struct drm_atomic_sta
 	ret = vop2_clk_set_parent_extend(vp, vcstate, true);
 	if (ret < 0)
 		goto out;
+
+	/*
+	 * For RK3576 MIPI/DSI output, switch dclk_src parent from vpll
+	 * to cpll. This prevents DP's vpll reprogramming from breaking
+	 * DSI pixel clock when both displays are active.
+	 * cpll at 1000MHz supports 720x1280@60 exactly (1000/12=83.33MHz).
+	 */
+	if (vop2->version == VOP_VERSION_RK3576 &&
+	    (vcstate->output_if & (VOP_OUTPUT_IF_MIPI0 | VOP_OUTPUT_IF_MIPI1))) {
+		struct clk_hw *dclk_hw = __clk_get_hw(vp->dclk);
+		if (dclk_hw) {
+			struct clk_hw *src_hw = clk_hw_get_parent(dclk_hw);
+			if (src_hw) {
+				struct clk *cpll = __clk_lookup("cpll");
+				if (cpll)
+					clk_set_parent(src_hw->clk, cpll);
+			}
+		}
+	}
 	if (dclk)
 		dclk_rate = dclk->rate;
 	else


### PR DESCRIPTION
## Summary

Two fixes for RK3576 MIPI/DSI output when used alongside other displays.

### Patches

1. **drm/rockchip: rk3576: switch DSI dclk_src from vpll to cpll** — When both DP and DSI are active, DP reprograms vpll which breaks DSI pixel clock. Switch DSI VP's dclk parent to cpll (1000MHz, supports 720x1280@60 exactly).

2. **drm/rockchip: dw-mipi-dsi2: set panel orientation before device registration** — Fixes  when DSI panel driver calls  from  after DRM device registration.

## Test plan

- [x] Simultaneous HDMI + DP + DSI output works without pixel clock issues
- [x] DSI panel (ili9881c) with portrait orientation: no kernel WARNING
- [x] No regressions on single-display configurations