### PR TITLE
arm64: dts: rockchip: fix dynamic dclk for CM3588-NAS

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-friendlyelec-cm3588-nas.dts
@@ -220,6 +220,11 @@
 	status = "okay";
 };
 
+&display_subsystem {
+	clocks = <&hdptxphy_hdmi0>, <&hdptxphy_hdmi1>;
+	clock-names = "hdmi0_phy_pll", "hdmi1_phy_pll";
+};
+
 &dp0 {
 	status = "okay";
 };


### PR DESCRIPTION
- from https://github.com/friendlyarm/kernel-rockchip/commit/cf3956d9f437d549b17c2c237f653c5b7b040712#diff-4425cc4841f2fe595f53f6743b3f28a323ea66815a615f3392cd6e84ea881c83