### PR TITLE
input: remotectl: rockchip-pwm: prefer dedicated channel-3 IRQ

### DIFF
--- a/drivers/input/remotectl/rockchip_pwm_remotectl.c
+++ b/drivers/input/remotectl/rockchip_pwm_remotectl.c
@@ -932,7 +932,17 @@ static int rk_pwm_probe(struct platform_device *pdev)
 	input->id.product = 0x0006;
 	input->id.version = 0x0100;
 	ddata->input = input;
-	irq = platform_get_irq(pdev, 0);
+	/*
+	 * On PWM v4 (RK3588), channel 3 has a dedicated capture IRQ at
+	 * index 1, separate from the group IRQ at index 0 that is shared
+	 * with the other channels in the same PWM controller. Prefer the
+	 * dedicated one so we don't collide with the pwm-rockchip driver
+	 * bound to another channel (which claims the group IRQ without
+	 * IRQF_SHARED on v4). Fall back to index 0 for older PWM v1-v3.
+	 */
+	irq = platform_get_irq(pdev, 1);
+	if (irq < 0)
+		irq = platform_get_irq(pdev, 0);
 	if (irq < 0) {
 		dev_err(&pdev->dev, "cannot find IRQ\n");
 		goto error_pclk;


### PR DESCRIPTION
On PWM v4 (RK3588), channel 3 of each PWM controller block exposes two interrupts: a group IRQ at index 0 shared with channels 0/1/2 of the same block, and a dedicated capture IRQ at index 1 intended for IR receive / power-key wakeup use of channel 3.

The driver always grabbed index 0 and requested it without IRQF_SHARED, which collides with pwm-rockchip when another channel in the same block is enabled (e.g. pwm1 for a fan on the FriendlyElec CM3588-NAS). The in-tree v4 path in pwm-rockchip.c also omits IRQF_SHARED, so probe fails with -EBUSY:

  remotectl-pwm fd8b0030.pwm: cannot claim IRQ 28
  remotectl-pwm: probe of fd8b0030.pwm failed with error -16

Prefer index 1 when present and fall back to index 0 for PWM v1-v3 nodes that only expose a single interrupt. The capture-mode handler (rockchip_pwm_irq_v4) is unchanged and remains correct for the dedicated IRQ.