### PR TITLE
luckfox-lyra-ultra-w: Add spidev overlay with 2 CS

### DIFF
--- a/arch/arm/boot/dts/overlay/Makefile
+++ b/arch/arm/boot/dts/overlay/Makefile
@@ -11,6 +11,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-luckfox-lyra-plus-spi0-1cs-spidev.dtbo \
 	rockchip-luckfox-lyra-plus-spi0-2cs-spidev.dtbo \
 	rockchip-luckfox-lyra-ultra-w-spi0-1cs-spidev.dtbo \
+	rockchip-luckfox-lyra-ultra-w-spi0-2cs-spidev.dtbo \
 	rockchip-luckfox-lyra-zero-w-ipex-antenna.dtbo \
 	rockchip-luckfox-lyra-zero-w-spi0-1cs-spidev.dtbo \
 	rockchip-luckfox-lyra-zero-w-spi0-2cs-spidev.dtbo \

--- a/arch/arm/boot/dts/overlay/README.rockchip-overlays
+++ b/arch/arm/boot/dts/overlay/README.rockchip-overlays
@@ -31,6 +31,7 @@ for Luckfox Lyra Plus:
 
 for Luckfox Lyra Ultra W:
 - spi0-1cs-spidev
+- spi0-2cs-spidev
 
 for Luckfox Lyra Zero W:
 - ipex-antenna
@@ -90,6 +91,9 @@ Retains pin-compatibility with Luckfox Pico Plus.
 ### luckfox-lyra-ultra-w-spi0-1cs-spidev
 Enables SPI0 spidev on luckfox-lyra-ultra-w with one chipselect.
 Retains pin-compatibility with Luckfox Pico Ultra.
+
+### luckfox-lyra-ultra-w-spi0-2cs-spidev
+Enables SPI0 spidev on luckfox-lyra-ultra-w with two chipselects.
 
 ### luckfox-lyra-zero-w-ipex-antenna
 Switches wifi/bluetooth from the onboard antenna to the external IPEX connector.

--- a/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-ultra-w-spi0-2cs-spidev.dts
+++ b/arch/arm/boot/dts/overlay/rockchip-luckfox-lyra-ultra-w-spi0-2cs-spidev.dts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Enable spidev on SPI0 with explicit RM_IO pinmux:
+ * MOSI = RM_IO6, MISO = RM_IO7, CLK = RM_IO8, CS0 = RM_IO10, CS1 = RM_IO9
+ */
+
+/dts-v1/;
+/plugin/;
+
+/ {
+	metadata {
+		title = "Enable SPI0 spidev on luckfox-lyra-ultra-w";
+		compatible = "rockchip,rk3506b-lyra-ultra";
+		category = "spi";
+		exclusive = "spi0", "RM_IO6", "RM_IO7", "RM_IO8", "RM_IO9", "RM_IO10";
+		description = "Enable SPI0 spidev using RM_IO6(MOSI), RM_IO7(MISO), RM_IO8(CLK), RM_IO10(CS0), RM_IO9(CS1).";
+	};
+};
+
+&spi0 {
+	status = "okay";
+	num-cs = <2>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&rm_io8_spi0_clk &rm_io7_spi0_miso &rm_io6_spi0_mosi &rm_io10_spi0_csn0 &rm_io9_spi0_csn1>;
+
+	spi@0 {
+		compatible = "rockchip,spidev";
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+
+	spi@1 {
+		compatible = "rockchip,spidev";
+		reg = <1>;
+		spi-max-frequency = <50000000>;
+		status = "okay";
+	};
+};


### PR DESCRIPTION
Adds spidev overlay with 2 chipselect lines for Luckfox Lyra Ultra, mirroring raspberry-pi placement (Lyra Ultra pinout mirrors the first 26pins of a raspberry pi)