### PR TITLE
yy3588: fix eDP video port and timing, document panel requirement

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/youyeetoo-yy3588-display-dsi0.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/youyeetoo-yy3588-display-dsi0.dts
@@ -15,7 +15,7 @@
 		title = "Enable DSI0 Display on Youyeetoo YY3588";
 		compatible = "youyeetoo,yy3588";
 		category = "display";
-		description = "Enable 7 inch 1024x600 MIPI DSI0 display with GT911 touchscreen";
+		description = "Enable 7 inch 1024x600 MIPI DSI0 display with GT911 touchscreen. Enable this overlay only with the panel connected or the display subsystem stalls at boot";
 	};
 
 	fragment@0 {

--- a/arch/arm64/boot/dts/rockchip/overlay/youyeetoo-yy3588-display-dsi1.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/youyeetoo-yy3588-display-dsi1.dts
@@ -15,7 +15,7 @@
 		title = "Enable DSI1 Display on Youyeetoo YY3588";
 		compatible = "youyeetoo,yy3588";
 		category = "display";
-		description = "Enable 7 inch 1024x600 MIPI DSI1 display with GT911 touchscreen";
+		description = "Enable 7 inch 1024x600 MIPI DSI1 display with GT911 touchscreen. Enable this overlay only with the panel connected or the display subsystem stalls at boot";
 	};
 
 	fragment@0 {

--- a/arch/arm64/boot/dts/rockchip/overlay/youyeetoo-yy3588-display-edp.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/youyeetoo-yy3588-display-edp.dts
@@ -14,7 +14,7 @@
 		title = "Enable eDP Display on Youyeetoo YY3588";
 		compatible = "youyeetoo,yy3588";
 		category = "display";
-		description = "Enable 11.6 inch 1920x1080 eDP display with GT928 touchscreen";
+		description = "Enable 11.6 inch 1920x1080 eDP display with GT928 touchscreen. The panel HPD line is not wired (force-hpd), enable this overlay only with the panel connected or the display subsystem stalls at boot";
 	};
 
 	fragment@0 {
@@ -84,6 +84,9 @@
 				height-mm = <144>;
 				status = "okay";
 
+				/* BOE QV116FHB-N81 datasheet typical timing. The EDID
+				 * preferred 147.7MHz mode flickers on this eDP link.
+				 */
 				panel-timing {
 					clock-frequency = <141500000>;
 					hactive = <1920>;
@@ -161,7 +164,7 @@
 		target = <&edp1_in_vp1>;
 
 		__overlay__ {
-			status = "okay";
+			status = "disabled";
 		};
 	};
 
@@ -169,7 +172,7 @@
 		target = <&edp1_in_vp2>;
 
 		__overlay__ {
-			status = "disabled";
+			status = "okay";
 		};
 	};
 
@@ -178,7 +181,26 @@
 
 		__overlay__ {
 			status = "okay";
-			connect = <&vp1_out_edp1>;
+			connect = <&vp2_out_edp1>;
+		};
+	};
+
+	/* dp0 owns VP2 in the board DTS; hand it VP1 so eDP can use VP2,
+	 * matching the vendor VOP port mux arrangement.
+	 */
+	fragment@10 {
+		target = <&dp0_in_vp2>;
+
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@11 {
+		target = <&dp0_in_vp1>;
+
+		__overlay__ {
+			status = "okay";
 		};
 	};
 


### PR DESCRIPTION
Follow-up to #507 after testing the eDP kit on YY3588 hardware.

eDP on VP1 does not work in practice: VP1 shares its PLL with VP0, the 141.5MHz dclk gets clamped to 132MHz and the VOP2 port mux times out on the second modeset, so the screen dies right after the boot logo. eDP now runs on VP2 like the vendor tree and DP moves to VP1. The panel timing follows the BOE QV116FHB-N81 datasheet typical, and the panel enable GPIO is dropped since GPIO0_C4 already belongs to the always-on wifi_disable regulator in the board DTS.

The overlay descriptions now warn that a display overlay must not be enabled without its panel attached: with the vendor kernel the display-subsystem bind stalls at boot, on eDP because force-hpd keeps training against a missing sink.

Tested on YY3588: dsi1 kit working with display and GT911 touch, eDP verified up to a stable 1920x1080p60 link (the sample kit here has an analog defect, so panel-side validation is partial).
