### PR TITLE
arm64: dts: rockchip: yy3588: drop unused wifi_disable regulator

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-youyeetoo-yy3588.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-youyeetoo-yy3588.dts
@@ -310,15 +310,6 @@
 		regulator-min-microvolt = <12000000>;
 		regulator-name = "vcc12v_dcin";
 	};
-
-	wifi_disable: wifi-disable-gpio-regulator {
-		compatible = "regulator-fixed";
-		enable-active-high;
-		gpio = <&gpio0 RK_PC4 GPIO_ACTIVE_HIGH>;
-		regulator-always-on;
-		regulator-boot-on;
-		regulator-name = "wifi_disable";
-	};
 };
 
 &av1d {


### PR DESCRIPTION
The wifi_disable fixed regulator is never used as a supply by anything. It only holds GPIO0_C4 high at boot, and on this board that pin is not a Wi-Fi control at all.

Wi-Fi on the YY3588 is a PCIe RTL8852BE module on its own standby rail, independent of this GPIO. GPIO0_C4 is actually the eDP backlight PWM pin (pwm2_m0). The node was carried over from a radxa reference and just steals that pad.

This drops the node. Wi-Fi and Bluetooth were checked working on the board with the regulator gone.
