### PR TITLE
Add kernel level support for KICKPI K3B

### DIFF
--- a/arch/arm64/boot/dts/rockchip/Makefile
+++ b/arch/arm64/boot/dts/rockchip/Makefile
@@ -119,6 +119,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-rock-2a.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-rock-2f.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-nanopi-rev01.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3562-dictpen-test3-v20.dtb
+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3562-kickpi-k3b.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3562-evb1-lp4x-v10.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3562-evb1-lp4x-v10-linux.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3562-evb1-lp4x-v10-linux-amp.dtb

--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
@@ -139,6 +139,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3588-panthor-gpu.dtbo \
 	rk3528-rock-2-enable-pcie.dtbo \
 	rk3566-roc-pc-sata2.dtbo \
+	rk3562-kickpi-k3b-demo-dsi-panel.dtbo \
 	rk3576-can1-m1.dtbo \
 	rk3576-i2c0-m1.dtbo \
 	rk3576-i2c1-m0.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlay/rk3562-kickpi-k3b-demo-dsi-panel.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/rk3562-kickpi-k3b-demo-dsi-panel.dts
@@ -1,0 +1,257 @@
+/dts-v1/;
+/plugin/;
+
+/*
+ * Simple reference DSI panel DT overlay.
+ * Works with JD9366-based 800x1280 panels.
+ * Verified on SQ101P-X4EI451-84H501 and YDP1010BT003-V1.
+ */
+
+#include <dt-bindings/display/drm_mipi_dsi.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+
+/ {
+	fragment@0 {
+		target-path = "/";
+
+		__overlay__ {
+			lcd_3v3: regulator-lcd-3v3 {
+				compatible = "regulator-fixed";
+				enable-active-high;
+				gpio = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&lcd_3v3_pin>;
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-name = "lcd_3v3";
+				vin-supply = <&vcc_3v3>;
+			};
+
+			backlight_dsi: backlight-dsi {
+				compatible = "gpio-backlight";
+				gpios = <&gpio0 RK_PC2 GPIO_ACTIVE_HIGH>; /* This enabled fixed 24v VLED */
+				default-on;
+				pinctrl-names = "default";
+				pinctrl-0 = <&lcd_vled_pin>;
+			};
+		};
+	};
+
+	fragment@1 {
+		target = <&dsi>;
+
+		__overlay__ {
+			status = "okay";
+
+			panel-dsi@0 {
+				reg = <0>;
+				compatible = "simple-panel-dsi";
+				pinctrl-names = "default";
+				pinctrl-0 = <&lcd_reset_pin>;
+				backlight = <&backlight_dsi>;
+				power-supply = <&lcd_3v3>;
+				reset-gpios = <&gpio0 RK_PA7 GPIO_ACTIVE_LOW>;
+
+				reset-delay-ms = <120>;
+				enable-delay-ms = <120>;
+				prepare-delay-ms = <120>;
+				init-delay-ms = <120>;
+				unprepare-delay-ms = <60>;
+				disable-delay-ms = <60>;
+
+				dsi,flags = <(MIPI_DSI_MODE_VIDEO | MIPI_DSI_MODE_VIDEO_BURST |
+					MIPI_DSI_MODE_LPM | MIPI_DSI_MODE_NO_EOT_PACKET)>;
+				dsi,format = <MIPI_DSI_FMT_RGB888>;
+				dsi,lanes = <4>;
+
+				panel-init-sequence = [
+					23 00 02 30 01
+					39 00 05 78 49 61 02 00
+					23 00 02 30 02
+					23 00 02 31 12
+					23 00 02 32 08
+					23 00 02 33 3f
+					23 00 02 3c 04
+					23 00 02 3d 78
+					23 00 02 3e 43
+					23 00 02 3f 30
+					23 00 02 42 a2
+					23 00 02 43 f0
+					23 00 02 44 01
+					23 00 02 46 17
+					23 00 02 49 c0
+					23 00 02 6d 30
+					23 00 02 6e 21
+					39 00 0d 41 5b 5b 03 03 5b 5b 02 02 03 03 03 03
+					39 00 0c 5a 00 00 34 34 31 31 23 23 24 24 23
+					39 00 0c 5b 23 0b 0b 09 09 0f 0f 0d 0d 06 06
+					39 00 0c 5c 00 00 34 34 31 31 23 23 24 24 23
+					39 00 0c 5d 23 0a 0a 08 08 0e 0e 0c 0c 05 05
+					39 00 0c 5e 00 00 31 31 34 34 23 23 24 24 23
+					39 00 0c 5f 23 0c 0c 0e 0e 08 08 0a 0a 05 05
+					39 00 0c 60 00 00 31 31 34 34 23 23 24 24 23
+					39 00 0c 61 23 0d 0d 0f 0f 09 09 0b 0b 06 06
+					39 00 04 64 ff ff 3f
+					39 00 04 65 ff ff 3f
+					39 00 04 6f 03 00 00
+					39 00 04 70 03 00 00
+					39 00 04 71 00 00 80
+					39 00 04 72 00 00 00
+					39 00 03 4c 22 22
+					23 00 02 73 2a
+					39 00 03 4e 00 00
+					39 00 03 50 00 00
+					39 00 03 55 ff ff
+					39 00 03 56 ff ff
+					39 00 03 57 00 00
+					39 00 03 58 ff ff
+					39 00 03 66 ff ff
+					39 00 03 67 ff ff
+					23 00 02 4a 3f
+					23 00 02 30 08
+					23 00 02 31 65
+					23 00 02 33 05
+					23 00 02 40 50
+					23 00 02 41 80
+					23 00 02 42 1a
+					23 00 02 47 0a
+					23 00 02 48 0d
+					23 00 02 50 17
+					23 00 02 5a 20
+					23 00 02 5b 00
+					23 00 02 5c 53
+					23 00 02 62 04
+					23 00 02 65 5f
+					23 00 02 73 01
+					23 00 02 30 0a
+					23 00 02 32 ff
+					23 00 02 33 28
+					23 00 02 3f 53
+					23 00 02 40 15
+					23 00 02 47 20
+					23 00 02 48 80
+					23 00 02 49 03
+					23 00 02 30 0b
+					39 00 03 33 00 3d
+					39 00 03 3c 00 bf
+					23 00 02 43 b1
+					23 00 02 44 31
+					39 00 06 3e 00 10 1e 27 2f
+					39 00 0f 3f 54 6f 73 7c 77 91 90 99 a8 a5 ae b5 c5 b8
+					39 00 0a 40 52 52 53 7f 00 10 1e 27 2f
+					39 00 0f 41 54 6f 73 7c 77 91 98 99 a8 a5 ae b5 c5 b8
+					39 00 05 42 52 52 53 7f
+					23 00 02 45 70
+					23 00 02 46 3b
+					23 00 02 48 7c
+					23 00 02 49 1e
+					23 00 02 4a 3a
+					23 00 02 30 0c
+					23 00 02 32 62
+					23 00 02 71 77
+					23 00 02 30 0d
+					23 00 02 4c 74
+					23 00 02 30 00
+					05 78 01 11
+					05 0a 01 29
+					23 00 02 35 00
+				];
+
+				panel-exit-sequence = [
+					05 00 01 28
+					05 00 01 10
+				];
+
+				display-timings {
+					native-mode = <&dsi0_timing0>;
+					dsi0_timing0: timing0 {
+						clock-frequency = <76106880>;
+						hactive = <800>;
+						vactive = <1280>;
+						hback-porch = <28>;
+						hfront-porch = <40>;
+						vback-porch = <20>;
+						vfront-porch = <140>;
+						hsync-len = <8>;
+						vsync-len = <8>;
+						hsync-active = <0>;
+						vsync-active = <0>;
+						de-active = <0>;
+						pixelclk-active = <0>;
+					};
+				};
+
+				ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					port@0 {
+						reg = <0>;
+						panel_in_dsi: endpoint {
+							remote-endpoint = <&dsi_out_panel>;
+						};
+					};
+				};
+			};
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@1 {
+					reg = <1>;
+					dsi_out_panel: endpoint {
+						remote-endpoint = <&panel_in_dsi>;
+					};
+				};
+			};
+		};
+	};
+
+	fragment@2 {
+		target = <&dsi_in_vp0>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@3 {
+		target = <&video_phy>;
+
+		__overlay__ {
+			status = "okay";
+		};
+	};
+
+	fragment@4 {
+		target = <&route_dsi>;
+
+		__overlay__ {
+			status = "okay";
+			connect = <&vp0_out_dsi>;
+		};
+	};
+
+	fragment@5 {
+		target = <&pinctrl>;
+
+		__overlay__ {
+			display {
+				lcd_3v3_pin: lcd-3v3-pin {
+					rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
+				};
+
+				lcd_vled_pin: lcd-vled-pin {
+					rockchip,pins = <0 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
+				};
+
+				lcd_reset_pin: lcd-reset-pin {
+					rockchip,pins = <0 RK_PA7 RK_FUNC_GPIO &pcfg_pull_none>;
+				};
+			};
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/rk3562-kickpi-k3b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3562-kickpi-k3b.dts
@@ -1,0 +1,793 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2022 Fuzhou Rockchip Electronics Co., Ltd.
+ * Copyright (c) 2026 retro98boy <retro98boy@qq.com>
+ */
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/leds/common.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include "rk3562.dtsi"
+/*
+ * Include configurations for the Linux system.
+ * Replace this with rk3562-android.dtsi to
+ * adapt this DTS for the Android system.
+ */
+#include "rk3562-linux.dtsi"
+
+#define USE_PANFROST
+
+/ {
+	model = "KICKPI K3B";
+	compatible = "kickpi,k3b", "rockchip,rk3562";
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		work-led {
+			color = <LED_COLOR_ID_BLUE>;
+			linux,default-trigger = "heartbeat";
+			function = LED_FUNCTION_HEARTBEAT;
+			gpios = <&gpio1 RK_PC7 GPIO_ACTIVE_HIGH>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&work_led_pin>;
+		};
+
+		/*
+		 * The KICKPI K3B has a hardware quirk:
+		 * if the battery functionality is enabled in software
+		 * but no physical battery is connected,
+		 * powering the device via Type-C will cause it to hang
+		 * during the boot process.
+		 * To workaround this issue, KICKPI introduces a 10-second
+		 * delay before enabling the USB Type-A power supply.
+		 * Note that the initial-on-delay-ms property requires
+		 * a specific kernel patch to be supported.
+		 */
+		vcc5v0-usb {
+			label = "vcc5v0-usb";
+			default-state = "on";
+			initial-on-delay-ms = <10000>;
+			gpios = <&gpio3 RK_PC6 GPIO_ACTIVE_HIGH>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&vcc5v0_usb_pin>;
+		};
+	};
+
+	sdio_pwrseq: sdio-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		clocks = <&rk817 1>;
+		clock-names = "ext_clock";
+		pinctrl-names = "default";
+		pinctrl-0 = <&wifi_enable_h>;
+		post-power-on-delay-ms = <200>;
+		reset-gpios = <&gpio0 RK_PB3 GPIO_ACTIVE_LOW>;
+	};
+
+	test-power {
+		status = "okay";
+	};
+
+	analog-sound {
+		compatible = "rockchip,multicodecs-card";
+		rockchip,card-name = "kickpi-k3b";
+		hp-det-gpio = <&gpio3 RK_PD0 GPIO_ACTIVE_HIGH>;
+		rockchip,format = "i2s";
+		rockchip,mclk-fs = <256>;
+		rockchip,cpu = <&sai0>;
+		rockchip,codec = <&rk817_codec>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&hp_det_pin>;
+		io-channels = <&saradc0 0>;
+		io-channel-names = "adc-detect";
+		keyup-threshold-microvolt = <1800000>;
+
+		play-pause-key {
+			label = "playpause";
+			linux,code = <KEY_PLAYPAUSE>;
+			press-threshold-microvolt = <2000>;
+		};
+	};
+
+	vcc_sys: regulator-vcc-sys {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_sys";
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
+	vcc5v0_usb_otg: regulator-vcc5v0-usb-otg {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc5v0_usb_otg";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+	};
+
+	vcc3v3_sd: regulator-vcc3v3-sd {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc3v3_sd";
+		regulator-boot-on;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		enable-active-low;
+		gpio = <&gpio0 RK_PA5 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&vcc3v3_sd_pin>;
+		vin-supply = <&vcc_3v3>;
+	};
+
+	vdd_gpu: regulator-vdd-gpu {
+		compatible = "pwm-regulator";
+		pwms = <&pwm7 0 5000 1>;
+		regulator-name = "vdd_gpu";
+		regulator-min-microvolt = <800000>;
+		regulator-max-microvolt = <1100000>;
+		regulator-init-microvolt = <900000>;
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-settling-time-up-us = <250>;
+		pwm-supply = <&vcc_sys>;
+	};
+
+	vdd_npu: regulator-vdd-npu {
+		compatible = "pwm-regulator";
+		pwms = <&pwm6 0 5000 1>;
+		regulator-name = "vdd_npu";
+		regulator-min-microvolt = <800000>;
+		regulator-max-microvolt = <1100000>;
+		regulator-init-microvolt = <900000>;
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-settling-time-up-us = <250>;
+		pwm-supply = <&vcc_sys>;
+	};
+
+	wireless-wlan {
+		compatible = "wlan-platdata";
+		rockchip,grf = <&sys_grf>;
+		wifi_chip_type = "rtl8822cs"; /* Not care */
+		/* WIFI,poweren_gpio = <&gpio0 RK_PB3 GPIO_ACTIVE_HIGH>; */
+		WIFI,host_wake_irq = <&gpio0 RK_PB4 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&wifi_host_wake_irq>;
+	};
+
+	wireless-bluetooth {
+		compatible = "bluetooth-platdata";
+		clocks = <&rk817 1>;
+		clock-names = "ext_clock";
+		uart_rts_gpios = <&gpio1 RK_PD3 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "default", "rts_gpio";
+		pinctrl-0 = <&uart1m0_rtsn>;
+		pinctrl-1 = <&uart1_gpios>;
+		BT,power_gpio = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
+		BT,wake_gpio = <&gpio0 RK_PC6 GPIO_ACTIVE_HIGH>;
+		BT,wake_host_irq = <&gpio0 RK_PC7 GPIO_ACTIVE_HIGH>;
+	};
+
+	bt_sco: bt-sco {
+		compatible = "delta,dfbmcs320";
+		#sound-dai-cells = <1>;
+	};
+
+	bt-sound {
+		compatible = "simple-audio-card";
+		simple-audio-card,format = "dsp_a";
+		simple-audio-card,bitclock-inversion = <0>;
+		simple-audio-card,mclk-fs = <256>;
+		simple-audio-card,name = "rockchip,bt";
+
+		simple-audio-card,cpu {
+			sound-dai = <&sai2>;
+		};
+
+		simple-audio-card,codec {
+			sound-dai = <&bt_sco 1>;
+		};
+	};
+};
+
+&chosen {
+	/* Override incompatible settings from rk3562-linux.dtsi */
+	bootargs = "earlycon=uart8250,mmio32,0xff210000 console=ttyFIQ0";
+};
+
+&combphy_pu {
+	status = "okay";
+};
+
+&cpu0 {
+	cpu-supply = <&vdd_cpu>;
+};
+
+&dfi {
+	status = "okay";
+};
+
+&display_subsystem {
+	status = "okay";
+};
+
+&dmc {
+	center-supply = <&vdd_logic>;
+	status = "okay";
+};
+
+&gmac0 {
+	phy-handle = <&mae0621a>;
+	phy-mode = "rgmii";
+	clock_in_out = "output";
+	tx_delay = <0x47>;
+	rx_delay = <0x3f>;
+
+	snps,reset-gpio = <&gpio3 RK_PA0 GPIO_ACTIVE_LOW>;
+	snps,reset-active-low;
+	snps,reset-delays-us = <0 20000 100000>;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&rgmiim0_miim
+		&rgmiim0_tx_bus2
+		&rgmiim0_rx_bus2
+		&rgmiim0_rgmii_clk
+		&rgmiim0_rgmii_bus>;
+
+	status = "okay";
+};
+
+&gpu {
+#ifdef USE_PANFROST
+	interrupt-names = "gpu", "mmu", "job";
+#endif
+	mali-supply = <&vdd_gpu>;
+	status = "okay";
+};
+
+#ifdef USE_PANFROST
+&gpu_opp_table {
+	opp-300000000 {
+		/delete-property/ opp-supported-hw;
+	};
+
+	opp-400000000 {
+		/delete-property/ opp-supported-hw;
+	};
+
+	opp-500000000 {
+		/delete-property/ opp-supported-hw;
+	};
+
+	opp-600000000 {
+		/delete-property/ opp-supported-hw;
+	};
+
+	opp-700000000 {
+		/delete-property/ opp-supported-hw;
+	};
+
+	opp-800000000 {
+		/delete-property/ opp-supported-hw;
+	};
+
+	opp-900000000 {
+		/delete-property/ opp-supported-hw;
+	};
+};
+#endif
+
+&i2c0 {
+	status = "okay";
+
+	rk817: pmic@20 {
+		compatible = "rockchip,rk817";
+		reg = <0x20>;
+		interrupt-parent = <&gpio0>;
+		interrupts = <3 IRQ_TYPE_LEVEL_LOW>;
+		pinctrl-names = "default", "pmic-sleep",
+			"pmic-power-off", "pmic-reset";
+		pinctrl-0 = <&pmic_int>;
+		pinctrl-1 = <&soc_slppin_slp>, <&rk817_slppin_slp>;
+		pinctrl-2 = <&soc_slppin_gpio>, <&rk817_slppin_pwrdn>;
+		pinctrl-3 = <&soc_slppin_gpio>, <&rk817_slppin_rst>;
+		rockchip,system-power-controller;
+		wakeup-source;
+		#clock-cells = <1>;
+		clock-output-names = "rk808-clkout1", "rk808-clkout2";
+		pmic-reset-func = <0>;
+		vcc1-supply = <&vcc_sys>;
+		vcc2-supply = <&vcc_sys>;
+		vcc3-supply = <&vcc_sys>;
+		vcc4-supply = <&vcc_sys>;
+		vcc5-supply = <&vcc_sys>;
+		vcc6-supply = <&vcc_sys>;
+		vcc7-supply = <&vcc_sys>;
+		vcc8-supply = <&vcc_sys>;
+		vcc9-supply = <&dcdc_boost>;
+
+		pwrkey {
+			status = "okay";
+		};
+
+		pinctrl_rk8xx: pinctrl_rk8xx {
+			gpio-controller;
+			#gpio-cells = <2>;
+
+			rk817_slppin_null: rk817_slppin_null {
+				pins = "gpio_slp";
+				function = "pin_fun0";
+			};
+
+			rk817_slppin_slp: rk817_slppin_slp {
+				pins = "gpio_slp";
+				function = "pin_fun1";
+			};
+
+			rk817_slppin_pwrdn: rk817_slppin_pwrdn {
+				pins = "gpio_slp";
+				function = "pin_fun2";
+			};
+
+			rk817_slppin_rst: rk817_slppin_rst {
+				pins = "gpio_slp";
+				function = "pin_fun3";
+			};
+		};
+
+		regulators {
+			vdd_logic: DCDC_REG1 {
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <1350000>;
+				regulator-init-microvolt = <900000>;
+				regulator-ramp-delay = <6001>;
+				regulator-initial-mode = <0x2>;
+				regulator-name = "vdd_logic";
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+					regulator-suspend-microvolt = <900000>;
+				};
+			};
+
+			vdd_cpu: DCDC_REG2 {
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <500000>;
+				regulator-max-microvolt = <1350000>;
+				regulator-init-microvolt = <900000>;
+				regulator-ramp-delay = <6001>;
+				regulator-initial-mode = <0x2>;
+				regulator-name = "vdd_cpu";
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vcc_ddr: DCDC_REG3 {
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-initial-mode = <0x2>;
+				regulator-name = "vcc_ddr";
+
+				regulator-state-mem {
+					regulator-on-in-suspend;
+				};
+			};
+
+			vcc_3v3: DCDC_REG4 {
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-initial-mode = <0x2>;
+				regulator-name = "vcc_3v3";
+
+				regulator-state-mem {
+					regulator-on-in-suspend;
+					regulator-suspend-microvolt = <3300000>;
+				};
+			};
+
+			vcca1v8_pmu: LDO_REG1 {
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-name = "vcca1v8_pmu";
+
+				regulator-state-mem {
+					regulator-on-in-suspend;
+					regulator-suspend-microvolt = <1800000>;
+				};
+			};
+
+			vdda_0v9: LDO_REG2 {
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <900000>;
+				regulator-max-microvolt = <900000>;
+				regulator-name = "vdda_0v9";
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vdda0v9_pmu: LDO_REG3 {
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <900000>;
+				regulator-max-microvolt = <900000>;
+				regulator-name = "vdda0v9_pmu";
+
+				regulator-state-mem {
+					regulator-on-in-suspend;
+					regulator-suspend-microvolt = <900000>;
+				};
+			};
+
+			vccio_acodec: LDO_REG4 {
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-name = "vccio_acodec";
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vccio_sd: LDO_REG5 {
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-name = "vccio_sd";
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vcc3v3_pmu: LDO_REG6 {
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <3300000>;
+				regulator-max-microvolt = <3300000>;
+				regulator-name = "vcc3v3_pmu";
+
+				regulator-state-mem {
+					regulator-on-in-suspend;
+					regulator-suspend-microvolt = <3000000>;
+				};
+			};
+
+			vcc_1v8: LDO_REG7 {
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-name = "vcc_1v8";
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vcc1v8_dvp: LDO_REG8 {
+				regulator-min-microvolt = <1800000>;
+				regulator-max-microvolt = <1800000>;
+				regulator-name = "vcc1v8_dvp";
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			vcc2v8_dvp: LDO_REG9 {
+				regulator-min-microvolt = <2800000>;
+				regulator-max-microvolt = <2800000>;
+				regulator-name = "vcc2v8_dvp";
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			dcdc_boost: BOOST {
+				regulator-always-on;
+				regulator-boot-on;
+				regulator-min-microvolt = <4700000>;
+				regulator-max-microvolt = <5400000>;
+				regulator-name = "boost";
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+
+			otg_switch: OTG_SWITCH {
+				regulator-name = "otg_switch";
+
+				regulator-state-mem {
+					regulator-off-in-suspend;
+				};
+			};
+		};
+
+		rk817_codec: codec {
+			#sound-dai-cells = <0>;
+			compatible = "rockchip,rk817-codec";
+			clocks = <&mclkout_sai0>;
+			clock-names = "mclk";
+			assigned-clocks = <&mclkout_sai0>;
+			assigned-clock-rates = <12288000>;
+			pinctrl-names = "default";
+			pinctrl-0 = <&i2s0m0_mclk>;
+			hp-volume = <3>;
+			spk-volume = <3>;
+			mic-in-differential;
+		};
+
+		battery {
+			compatible = "rk817,battery";
+			ocv_table = <3400 3573 3620 3662 3691 3713 3735
+				3760 3791 3830 3878 3923 3958 3986
+				4014 4051 4094 4126 4153 4191 4204>;
+			design_capacity = <5000>;
+			design_qmax = <5000>;
+			bat_res = <100>;
+			sleep_enter_current = <300>;
+			sleep_exit_current = <300>;
+			sleep_filter_current = <100>;
+			power_off_thresd = <3400>;
+			zero_algorithm_vol = <3850>;
+			max_soc_offset = <60>;
+			monitor_sec = <5>;
+			sample_res = <10>;
+			virtual_power = <1>;
+		};
+
+		charger {
+			compatible = "rk817,charger";
+			min_input_voltage = <4000>;
+			max_input_current = <3000>;
+			max_chrg_current = <3500>;
+			max_chrg_voltage = <4350>;
+			chrg_term_mode = <0>;
+			chrg_finish_cur = <300>;
+			virtual_power = <0>;
+			dc_det_adc = <0>;
+			extcon = <&u2phy>;
+			gate_function_disable = <1>;
+		};
+	};
+};
+
+&jpegd {
+	status = "okay";
+};
+
+&jpegd_mmu {
+	status = "okay";
+};
+
+&mdio0 {
+	mae0621a: ethernet-phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0x0>;
+		clocks = <&cru CLK_GMAC_ETH_OUT2IO>;
+		assigned-clocks = <&cru CLK_GMAC_ETH_OUT2IO>;
+		assigned-clock-rates = <25000000>;
+	};
+};
+
+&mpp_srv {
+	status = "okay";
+};
+
+&pinctrl {
+	led {
+		work_led_pin: work-led-pin {
+			rockchip,pins = <1 RK_PC7 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		vcc5v0_usb_pin: vcc5v0-usb-pin {
+			rockchip,pins = <3 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
+	sdmmc {
+		vcc3v3_sd_pin: vcc3v3-sd-pin {
+			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
+	sound {
+		hp_det_pin: hp-det-pin {
+			rockchip,pins = <3 RK_PD0 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
+	wireless-wlan {
+		wifi_enable_h: wifi-enable-h {
+			rockchip,pins = <0 RK_PB3 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+
+		wifi_host_wake_irq: wifi-host-wake-irq {
+			rockchip,pins = <0 RK_PB4 RK_FUNC_GPIO &pcfg_pull_down>;
+		};
+	};
+
+	wireless-bluetooth {
+		uart1_gpios: uart1-gpios {
+			rockchip,pins = <1 RK_PD3 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+};
+
+&pwm6 {
+	status = "okay";
+};
+
+&pwm7 {
+	status = "okay";
+};
+
+&rga2 {
+	status = "okay";
+};
+
+&rga2_mmu {
+	status = "okay";
+};
+
+&rknpu {
+	rknpu-supply = <&vdd_npu>;
+	status = "okay";
+};
+
+&rknpu_mmu {
+	status = "okay";
+};
+
+&rkvdec {
+	status = "okay";
+};
+
+&rkvdec_mmu {
+	status = "okay";
+};
+
+&rkvenc {
+	status = "okay";
+};
+
+&rkvenc_mmu {
+	status = "okay";
+};
+
+&sai0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2s0m0_lrck
+		&i2s0m0_sclk
+		&i2s0m0_sdi0
+		&i2s0m0_sdo0>;
+};
+
+&sai2 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2s2m0_lrck
+		&i2s2m0_sclk
+		&i2s2m0_sdi
+		&i2s2m0_sdo>;
+};
+
+&saradc0 {
+	status = "okay";
+	vref-supply = <&vcc_1v8>;
+};
+
+&sdhci {
+	bus-width = <8>;
+	no-sdio;
+	no-sd;
+	non-removable;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
+	full-pwr-cycle-in-suspend;
+	status = "okay";
+};
+
+&sdmmc0 {
+	no-sdio;
+	no-mmc;
+	bus-width = <4>;
+	cap-mmc-highspeed;
+	cap-sd-highspeed;
+	supports-sd;
+	disable-wp;
+	sd-uhs-sdr104;
+	vmmc-supply = <&vcc3v3_sd>;
+	vqmmc-supply = <&vccio_sd>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&sdmmc0_bus4 &sdmmc0_clk &sdmmc0_cmd &sdmmc0_det>;
+	status = "okay";
+};
+
+&sdmmc1 {
+	no-sd;
+	no-mmc;
+	bus-width = <4>;
+	disable-wp;
+	cap-sd-highspeed;
+	cap-sdio-irq;
+	keep-power-in-suspend;
+	mmc-pwrseq = <&sdio_pwrseq>;
+	non-removable;
+	pinctrl-names = "default";
+	pinctrl-0 = <&sdmmc1_bus4 &sdmmc1_cmd &sdmmc1_clk>;
+	sd-uhs-sdr104;
+	status = "okay";
+};
+
+&tsadc {
+	status = "okay";
+};
+
+&uart1 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart1m0_xfer &uart1m0_ctsn>;
+};
+
+&u2phy {
+	status = "okay";
+};
+
+&u2phy_host {
+	status = "okay";
+};
+
+&u2phy_otg {
+	status = "okay";
+	vbus-supply = <&vcc5v0_usb_otg>;
+};
+
+&usb_host0_ehci {
+	status = "okay";
+};
+
+&usb_host0_ohci {
+	status = "okay";
+};
+
+&usbdrd30 {
+	status = "okay";
+};
+
+&usbdrd_dwc3 {
+	status = "okay";
+	dr_mode = "otg";
+	extcon = <&u2phy>;
+	maximum-speed = "high-speed";
+	phys = <&u2phy_otg>;
+	phy-names = "usb2-phy";
+	snps,dis_u2_susphy_quirk;
+	snps,usb2-lpm-disable;
+};
+
+&vop {
+	status = "okay";
+};
+
+&vop_mmu {
+	status = "okay";
+};

--- a/drivers/gpu/drm/panfrost/panfrost_device.c
+++ b/drivers/gpu/drm/panfrost/panfrost_device.c
@@ -3,6 +3,7 @@
 /* Copyright 2019 Linaro, Ltd, Rob Herring <robh@kernel.org> */
 
 #include <linux/clk.h>
+#include <linux/of.h>
 #include <linux/reset.h>
 #include <linux/platform_device.h>
 #include <linux/pm_domain.h>
@@ -33,9 +34,69 @@ static void panfrost_reset_fini(struct panfrost_device *pfdev)
 	reset_control_assert(pfdev->rstc);
 }
 
+static bool panfrost_is_extra_clock(int index, const char *id)
+{
+	/*
+	 * The first clock is the GPU core clock handled through pfdev->clock.
+	 * The optional "bus" clock is kept on the existing dedicated path.
+	 */
+	return (index > 0) && id && (strcmp(id, "bus") != 0);
+}
+
+static int panfrost_extra_clocks_init(struct panfrost_device *pfdev)
+{
+	struct device_node *np = pfdev->dev->of_node;
+	int count, i;
+
+	if (!np)
+		return 0;
+
+	count = of_count_phandle_with_args(np, "clocks", "#clock-cells");
+	if (count == -ENOENT)
+		return 0;
+	if (count < 0)
+		return count;
+	if (count <= 1)
+		return 0;
+
+	pfdev->extra_clocks = devm_kcalloc(pfdev->dev, count - 1,
+					   sizeof(*pfdev->extra_clocks),
+					   GFP_KERNEL);
+	if (!pfdev->extra_clocks)
+		return -ENOMEM;
+
+	for (i = 0; i < count; i++) {
+		const char *id;
+		struct clk *clk;
+
+		if (of_property_read_string_index(np, "clock-names", i, &id))
+			continue;
+
+		if (!panfrost_is_extra_clock(i, id))
+			continue;
+
+		clk = devm_clk_get_optional(pfdev->dev, id);
+		if (IS_ERR(clk)) {
+			dev_err(pfdev->dev, "get %s failed %ld\n",
+				id, PTR_ERR(clk));
+			return PTR_ERR(clk);
+		}
+
+		if (!clk)
+			continue;
+
+		pfdev->extra_clocks[pfdev->num_extra_clocks].id = id;
+		pfdev->extra_clocks[pfdev->num_extra_clocks].clk = clk;
+		pfdev->num_extra_clocks++;
+	}
+
+	return 0;
+}
+
 static int panfrost_clk_init(struct panfrost_device *pfdev)
 {
 	int err;
+	int i;
 	unsigned long rate;
 
 	pfdev->clock = devm_clk_get(pfdev->dev, NULL);
@@ -68,8 +129,26 @@ static int panfrost_clk_init(struct panfrost_device *pfdev)
 			goto disable_clock;
 	}
 
+	err = panfrost_extra_clocks_init(pfdev);
+	if (err)
+		goto disable_bus_clock;
+
+	for (i = 0; i < pfdev->num_extra_clocks; i++) {
+		rate = clk_get_rate(pfdev->extra_clocks[i].clk);
+		dev_info(pfdev->dev, "%s rate = %lu\n",
+			 pfdev->extra_clocks[i].id,
+			 rate);
+	}
+
+	err = clk_bulk_prepare_enable(pfdev->num_extra_clocks,
+				      pfdev->extra_clocks);
+	if (err)
+		goto disable_bus_clock;
+
 	return 0;
 
+disable_bus_clock:
+	clk_disable_unprepare(pfdev->bus_clock);
 disable_clock:
 	clk_disable_unprepare(pfdev->clock);
 
@@ -78,6 +157,7 @@ disable_clock:
 
 static void panfrost_clk_fini(struct panfrost_device *pfdev)
 {
+	clk_bulk_disable_unprepare(pfdev->num_extra_clocks, pfdev->extra_clocks);
 	clk_disable_unprepare(pfdev->bus_clock);
 	clk_disable_unprepare(pfdev->clock);
 }

--- a/drivers/gpu/drm/panfrost/panfrost_device.h
+++ b/drivers/gpu/drm/panfrost/panfrost_device.h
@@ -84,6 +84,8 @@ struct panfrost_device {
 	void __iomem *iomem;
 	struct clk *clock;
 	struct clk *bus_clock;
+	struct clk_bulk_data *extra_clocks;
+	int num_extra_clocks;
 	struct regulator_bulk_data *regulators;
 	struct reset_control *rstc;
 	/* pm_domains for devices with more than one. */

--- a/drivers/leds/leds-gpio.c
+++ b/drivers/leds/leds-gpio.c
@@ -16,6 +16,7 @@
 #include <linux/platform_device.h>
 #include <linux/property.h>
 #include <linux/slab.h>
+#include <linux/workqueue.h>
 #include "leds.h"
 
 struct gpio_led_data {
@@ -23,6 +24,9 @@ struct gpio_led_data {
 	struct gpio_desc *gpiod;
 	u8 can_sleep;
 	u8 blinking;
+	u8 pending_initial_on;
+	unsigned int initial_on_delay_ms;
+	struct delayed_work initial_on_work;
 	gpio_blink_set_t platform_gpio_blink_set;
 };
 
@@ -37,6 +41,9 @@ static void gpio_led_set(struct led_classdev *led_cdev,
 {
 	struct gpio_led_data *led_dat = cdev_to_gpio_led_data(led_cdev);
 	int level;
+
+	if (led_dat->pending_initial_on)
+		return;
 
 	if (value == LED_OFF)
 		level = 0;
@@ -62,10 +69,42 @@ static int gpio_led_set_blocking(struct led_classdev *led_cdev,
 	return 0;
 }
 
+static void gpio_led_initial_on_work(struct work_struct *work)
+{
+	struct gpio_led_data *led_dat = container_of(to_delayed_work(work),
+						     struct gpio_led_data, initial_on_work);
+
+	mutex_lock(&led_dat->cdev.led_access);
+
+	if (!led_dat->pending_initial_on)
+		goto unlock;
+
+	led_dat->pending_initial_on = 0;
+	led_dat->cdev.brightness = led_dat->cdev.max_brightness;
+	gpio_led_set(&led_dat->cdev, led_dat->cdev.brightness);
+
+unlock:
+	mutex_unlock(&led_dat->cdev.led_access);
+}
+
+static void gpio_led_cancel_initial_on_work(void *data)
+{
+	struct gpio_led_data *led_dat = data;
+
+	if (!led_dat->pending_initial_on)
+		return;
+
+	cancel_delayed_work_sync(&led_dat->initial_on_work);
+	led_dat->pending_initial_on = 0;
+}
+
 static int gpio_blink_set(struct led_classdev *led_cdev,
 	unsigned long *delay_on, unsigned long *delay_off)
 {
 	struct gpio_led_data *led_dat = cdev_to_gpio_led_data(led_cdev);
+
+	if (led_dat->pending_initial_on)
+		return 0;
 
 	led_dat->blinking = 1;
 	return led_dat->platform_gpio_blink_set(led_dat->gpiod, GPIO_LED_BLINK,
@@ -109,6 +148,12 @@ static int create_gpio_led(const struct gpio_led *template,
 		led_dat->platform_gpio_blink_set = blink_set;
 		led_dat->cdev.blink_set = gpio_blink_set;
 	}
+
+	led_dat->initial_on_delay_ms = 0;
+	if (fwnode)
+		fwnode_property_read_u32(fwnode, "initial-on-delay-ms",
+					 &led_dat->initial_on_delay_ms);
+
 	if (template->default_state == LEDS_GPIO_DEFSTATE_KEEP) {
 		state = gpiod_get_value_cansleep(led_dat->gpiod);
 		if (state < 0)
@@ -116,7 +161,15 @@ static int create_gpio_led(const struct gpio_led *template,
 	} else {
 		state = (template->default_state == LEDS_GPIO_DEFSTATE_ON);
 	}
-	led_dat->cdev.brightness = state;
+	if (led_dat->initial_on_delay_ms && state) {
+		led_dat->pending_initial_on = 1;
+		led_dat->cdev.brightness = LED_OFF;
+		state = 0;
+	} else {
+		led_dat->pending_initial_on = 0;
+		led_dat->cdev.brightness = state;
+	}
+
 	led_dat->cdev.max_brightness = 1;
 	if (!template->retain_state_suspended)
 		led_dat->cdev.flags |= LED_CORE_SUSPENDRESUME;
@@ -136,6 +189,20 @@ static int create_gpio_led(const struct gpio_led *template,
 		init_data.fwnode = fwnode;
 		ret = devm_led_classdev_register_ext(parent, &led_dat->cdev,
 						     &init_data);
+	}
+
+	if (ret < 0)
+		return ret;
+
+	if (led_dat->pending_initial_on) {
+		INIT_DELAYED_WORK(&led_dat->initial_on_work, gpio_led_initial_on_work);
+		ret = devm_add_action_or_reset(parent, gpio_led_cancel_initial_on_work,
+					       led_dat);
+		if (ret)
+			return ret;
+
+		schedule_delayed_work(&led_dat->initial_on_work,
+				      msecs_to_jiffies(led_dat->initial_on_delay_ms));
 	}
 
 	return ret;
@@ -326,6 +393,8 @@ static void gpio_led_shutdown(struct platform_device *pdev)
 
 	for (i = 0; i < priv->num_leds; i++) {
 		struct gpio_led_data *led = &priv->leds[i];
+
+		gpio_led_cancel_initial_on_work(led);
 
 		if (!(led->cdev.flags & LED_RETAIN_AT_SHUTDOWN))
 			gpio_led_set(&led->cdev, LED_OFF);

--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -50,6 +50,9 @@
 #include "dwxgmac2.h"
 #include "hwif.h"
 
+#define MAXIO_PHY_MAE0621A_Q2C_ID 0x7b744411
+#define MAXIO_PHY_MAE0621A_Q3C_ID 0x7b744412
+
 /* As long as the interface is active, we keep the timestamping counter enabled
  * with fine resolution and binary rollover. This avoid non-monotonic behavior
  * (clock jumps) when changing timestamping settings at runtime.
@@ -7731,6 +7734,16 @@ int stmmac_resume(struct device *dev)
 
 	stmmac_free_tx_skbufs(priv);
 	stmmac_clear_descriptors(priv, &priv->dma_conf);
+
+	/*
+	 * Provide RX CLK for Rockchip's DWMAC otherwise the controller will
+	 * fail to initialize with "DMA engine initialization failed".
+	 */
+	if (ndev->phydev->drv->config_init) {
+		if (ndev->phydev->phy_id == MAXIO_PHY_MAE0621A_Q2C_ID ||
+		    ndev->phydev->phy_id == MAXIO_PHY_MAE0621A_Q3C_ID)
+			ndev->phydev->drv->config_init(ndev->phydev);
+	}
 
 	stmmac_hw_setup(ndev, false);
 	stmmac_init_coalesce(priv);

--- a/drivers/net/phy/Kconfig
+++ b/drivers/net/phy/Kconfig
@@ -219,6 +219,11 @@ config MARVELL_88X2222_PHY
 	  Support for the Marvell 88X2222 Dual-port Multi-speed Ethernet
 	  Transceiver.
 
+config MAXIO_PHY
+	tristate "Maxio Ethernet PHYs"
+	help
+	  Support for the Maxio MAExxxx Ethernet PHYs
+
 config MAXLINEAR_GPHY
 	tristate "Maxlinear Ethernet PHYs"
 	select POLYNOMIAL if HWMON

--- a/drivers/net/phy/Makefile
+++ b/drivers/net/phy/Makefile
@@ -67,6 +67,7 @@ obj-$(CONFIG_LXT_PHY)		+= lxt.o
 obj-$(CONFIG_MARVELL_10G_PHY)	+= marvell10g.o
 obj-$(CONFIG_MARVELL_PHY)	+= marvell.o
 obj-$(CONFIG_MARVELL_88X2222_PHY)	+= marvell-88x2222.o
+obj-$(CONFIG_MAXIO_PHY)	+= maxio.o
 obj-$(CONFIG_MAXLINEAR_GPHY)	+= mxl-gpy.o
 obj-$(CONFIG_MEDIATEK_GE_PHY)	+= mediatek-ge.o
 obj-$(CONFIG_MESON_GXL_PHY)	+= meson-gxl.o

--- a/drivers/net/phy/maxio.c
+++ b/drivers/net/phy/maxio.c
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: GPL-2.0+
+/* drivers/net/phy/maxio.c
+ *
+ * Driver for Maxio PHYs
+ */
+#include <linux/bitops.h>
+#include <linux/phy.h>
+#include <linux/module.h>
+#include <linux/delay.h>
+#include <linux/device.h>
+#include <linux/mdio.h>
+#include <linux/timer.h>
+#include <linux/netdevice.h>
+#include <linux/version.h>
+
+/*
+ * Source from https://github.com/zuyih/linux-cubie/blob/c5ea47e5f899042abe54437ced1fd49ac1226582/drivers/net/phy/maxio.c,
+ * with minor modifications.
+ */
+#define MAXIO_PHY_VER			"v1.8.1.13-dirty"
+#define MAXIO_PAGE_SELECT		0x1f
+#define MAXIO_MAE0621A_WORK_STATUS_REG	0x1d
+#define MAXIO_MAE0621A_CLK_MODE_REG	0x02
+
+#define MAXIO_PHYSR_P_A43  (0X1A)
+#define MAXIO_PHY_LINK     (1<<2)
+#define MAXIO_PHY_DUPLEX   (1<<3)
+#define MAXIO_PHY_SPEED    (3<<4)
+#define MAXIO_PHY_1000M	   (0X20)
+#define MAXIO_PHY_100M     (0X10)
+#define MAXIO_PHY_10M      (0X00)
+
+#define AUTONEG_COMPLETED_INT_EN	(0x8)
+#define LINKOK				(0x4)
+#define AUTONEG_COMPLETED		(0x8)
+
+#define PHY_READ(a,b)		phy_read((a),(b))
+#define PHY_WRITE(a,b,c)	phy_write((a),(b),(c))
+
+int maxio_read_paged(struct phy_device *phydev, int page, u32 regnum)
+{
+	int ret = 0, oldpage;
+
+	oldpage = PHY_READ(phydev, MAXIO_PAGE_SELECT);
+	if (oldpage >= 0) {
+		PHY_WRITE(phydev, MAXIO_PAGE_SELECT, page);
+		ret = PHY_READ(phydev, regnum);
+	}
+	PHY_WRITE(phydev, MAXIO_PAGE_SELECT, oldpage);
+
+	return ret;
+}
+
+int maxio_write_paged(struct phy_device *phydev, int page, u32 regnum, u16 val)
+{
+	int ret = 0, oldpage;
+
+	oldpage = PHY_READ(phydev, MAXIO_PAGE_SELECT);
+	if (oldpage >= 0) {
+		PHY_WRITE(phydev, MAXIO_PAGE_SELECT, page);
+		ret = PHY_WRITE(phydev, regnum, val);
+	}
+
+	PHY_WRITE(phydev, MAXIO_PAGE_SELECT, oldpage);
+
+	return ret;
+}
+
+int maxio_adcc_check(struct phy_device *phydev)
+{
+	int ret = 0;
+	int adcvalue;
+	u32 regval;
+	int i;
+
+	maxio_write_paged(phydev, 0xd96, 0x2, 0x1fff );
+	maxio_write_paged(phydev, 0xd96, 0x2, 0x1000 );
+
+	for (i = 0; i < 4; i++) {
+		regval = 0xf908 + i * 0x100;
+		maxio_write_paged(phydev, 0xd8f, 0xb, regval );
+		adcvalue = maxio_read_paged(phydev, 0xd92, 0xb);
+		if (adcvalue & 0x1ff) {
+			 continue;
+		} else {
+			ret = -1;
+			break;
+		}
+	}
+
+	return ret;
+}
+
+int maxio_self_check(struct phy_device *phydev, int checknum)
+{
+	int ret = 0;
+	int i;
+
+	for (i = 0; i < checknum; i++) {
+		ret = maxio_adcc_check(phydev);
+		if (0 == ret) {
+			printk("MAE0621A READY\n");
+			break;
+		} else {
+			maxio_write_paged(phydev, 0x0, 0x0, 0x1940 );
+			PHY_WRITE(phydev, MAXIO_PAGE_SELECT, 0x0);
+			msleep(10);
+			maxio_write_paged(phydev, 0x0, 0x0, 0x1140 );
+			maxio_write_paged(phydev, 0x0, 0x0, 0x9140 );
+		}
+	}
+
+	maxio_write_paged(phydev, 0xd96, 0x2, 0xfff );
+	maxio_write_paged(phydev, 0x0, 0x0, 0x9140 );
+	PHY_WRITE(phydev, MAXIO_PAGE_SELECT, 0x0);
+
+	return ret;
+}
+
+static int maxio_mae0621a_resume(struct phy_device *phydev)
+{
+	int ret;
+
+	ret = genphy_resume(phydev);
+
+	ret |= PHY_WRITE(phydev, MII_BMCR, BMCR_RESET | PHY_READ(phydev, MII_BMCR));
+	msleep(20);
+
+	return ret;
+}
+
+static int maxio_mae0621a_suspend(struct phy_device *phydev)
+{
+	int ret = 0;
+
+	ret = genphy_suspend(phydev);
+	ret |= PHY_WRITE(phydev, MAXIO_PAGE_SELECT ,0);
+
+	return ret;
+}
+
+int maxio_restart_aneg(struct phy_device *phydev)
+{
+	int ctl = PHY_READ(phydev, MII_BMCR);
+
+	if (ctl < 0)
+		return ctl;
+
+	ctl |= BMCR_ANENABLE | BMCR_ANRESTART;
+
+	ctl &= ~BMCR_ISOLATE;
+
+	return PHY_WRITE(phydev, MII_BMCR, ctl);
+}
+
+static void phy_resolve_aneg_linkmode_maxio(struct phy_device *phydev){
+
+	int physr_p_a43 = maxio_read_paged(phydev,0xa43,MAXIO_PHYSR_P_A43);
+
+	if ((physr_p_a43&MAXIO_PHY_SPEED) == MAXIO_PHY_1000M) {
+		phydev->speed = SPEED_1000;
+	} else if ((physr_p_a43&MAXIO_PHY_SPEED) == MAXIO_PHY_100M) {
+		phydev->speed = SPEED_100;
+	} else if ((physr_p_a43&MAXIO_PHY_SPEED) == MAXIO_PHY_10M) {
+		phydev->speed = SPEED_10;
+	}
+
+	if (physr_p_a43 & MAXIO_PHY_DUPLEX) {
+		phydev->duplex = DUPLEX_FULL;
+	} else {
+		phydev->duplex = DUPLEX_HALF;
+	}
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+	genphy_read_lpa(phydev);
+#else
+	if (phydev->duplex == DUPLEX_FULL) {
+		int lpa = PHY_READ(phydev, MII_LPA);
+		phydev->pause = (lpa & LPA_PAUSE_CAP) ? 1 : 0;
+		phydev->asym_pause = (lpa & LPA_PAUSE_ASYM) ? 1 : 0;
+	}
+#endif
+}
+
+void phy_resolve_link_compatibility_maxio(struct phy_device *phydev)
+{
+	int *paras = (int *)phydev->priv;
+	int maxio_an_times = paras[0];
+	int link_stable = paras[1];
+	int iner, physr, insr;
+	iner = maxio_read_paged(phydev, 0xa42, 0x12);
+	if (iner&AUTONEG_COMPLETED_INT_EN) {
+		physr = maxio_read_paged(phydev, 0xa43, 0x1a);
+		if (physr & LINKOK) {
+			insr = maxio_read_paged(phydev, 0xa43, 0x1d);
+			if ((insr & AUTONEG_COMPLETED) == 0 && (link_stable == 0)) {
+				if (maxio_an_times < 4 ) {
+					maxio_restart_aneg(phydev);
+					phydev->link = 0;
+					maxio_an_times++;
+				} else if (maxio_an_times == 4) {
+					link_stable = 1;
+				}
+			} else if (insr & AUTONEG_COMPLETED) {
+				maxio_an_times = 0;
+				link_stable = 1;
+			}
+
+			if (link_stable == 1)
+				maxio_an_times = 0;
+		} else
+			link_stable = 0;
+	}
+
+	paras[0] = maxio_an_times;
+	paras[1] = link_stable;
+}
+
+static int maxio_mae0621a_status(struct phy_device *phydev)
+{
+	int err, old_link = phydev->link;
+
+	err = genphy_update_link(phydev);
+	if (err)
+		return err;
+
+	if (phydev->autoneg == AUTONEG_ENABLE && old_link && phydev->link)
+		return 0;
+
+	phydev->speed = SPEED_UNKNOWN;
+	phydev->duplex = DUPLEX_UNKNOWN;
+	phydev->pause = 0;
+	phydev->asym_pause = 0;
+
+	phy_resolve_aneg_linkmode_maxio(phydev);
+
+	if (phydev->autoneg == AUTONEG_ENABLE)
+		phy_resolve_link_compatibility_maxio(phydev);
+
+	return 0;
+}
+
+static void maxio_mae0621a_remove(struct phy_device *phydev)
+{
+	printk("maxio driver remove\r\n");
+	if (phydev->priv != NULL) {
+		kfree(phydev->priv);
+	}
+	phydev->priv=NULL;
+}
+
+static int maxio_mae0621a_config_init(struct phy_device *phydev)
+{
+	int ret = 0;
+
+	printk("MAXIO_PHY_VER: %s \n",MAXIO_PHY_VER);
+
+	/*
+	 * KICKPI K3B requires this (extracted from the maxio v1.8.1.1 driver),
+	 * otherwise a DMA reset error occurs on the RK3562 STMicro MAC.
+	 * What exactly does this do? I couldn't find this specific page in the datasheet...
+	 */
+	ret |= maxio_write_paged(phydev, 0xd92, 0x2, 0x200a);
+
+	ret |= maxio_write_paged(phydev, 0xda0, 0x10, 0xc13);
+	ret |= maxio_write_paged(phydev, 0x0, 0xd, 0x7);
+	ret |= maxio_write_paged(phydev, 0x0, 0xe, 0x3c);
+	ret |= maxio_write_paged(phydev, 0x0, 0xd, 0x4007);
+	ret |= maxio_write_paged(phydev, 0x0, 0xe, 0x0);
+	ret |= maxio_write_paged(phydev, 0xd96, 0x13, 0x7bc);
+	ret |= maxio_write_paged(phydev, 0xd8f, 0x8, 0x2500);
+	ret |= maxio_write_paged(phydev, 0xd90, 0x2, 0x1555);
+	ret |= maxio_write_paged(phydev, 0xd90, 0x5, 0x2b15);
+	ret |= maxio_write_paged(phydev, 0xd92, 0x14, 0xa);
+	ret |= maxio_write_paged(phydev, 0xd91, 0x7, 0x5b00);
+	ret |= maxio_write_paged(phydev, 0xd8f, 0x0, 0x300);
+	ret |= maxio_write_paged(phydev, 0xd92, 0xa, 0x8506);
+	ret |= maxio_write_paged(phydev, 0xd91, 0x6, 0x6870);
+	ret |= maxio_write_paged(phydev, 0xd91, 0x1, 0x940);
+	ret |= maxio_write_paged(phydev, 0xda0, 0x13, 0x1303);
+	ret |= maxio_write_paged(phydev, 0xd97, 0xc, 0x177);
+	ret |= maxio_write_paged(phydev, 0xd97, 0xb, 0x9a9);
+	ret |= maxio_write_paged(phydev, 0xa42, 0x12, 0x28);
+	ret |= maxio_write_paged(phydev, 0x0, 0x4, 0xde1);
+	ret |= maxio_write_paged(phydev, 0x0, 0x0, 0x9140);
+
+	PHY_WRITE(phydev, MAXIO_PAGE_SELECT, 0x0);
+
+	ret |= maxio_self_check(phydev,50);
+	msleep(100);
+
+	return 0;
+}
+
+static int maxio_mae0621a_probe(struct phy_device *phydev)
+{
+	int *paras;
+	paras = kzalloc( 2 * sizeof(int), GFP_KERNEL);
+	if (!paras)
+		return -ENOMEM;
+
+	phydev->priv = paras;
+
+	/*
+	 * KICKPI K3B requires this (extracted from the maxio v1.8.1.1 driver),
+	 * otherwise a DMA reset error occurs on the RK3562 STMicro MAC.
+	 * What exactly does this do? I couldn't find this specific page in the datasheet...
+	 */
+	maxio_write_paged(phydev, 0xd92, 0x2, 0x200a);
+
+	printk("maxio_mae0621a_probe clkmode(oscillator) PHY_ID: 0x%x\n", phydev->phy_id);
+
+	PHY_WRITE(phydev, MAXIO_PAGE_SELECT, 0x0);
+	mdelay(100);
+
+	return 0;
+}
+
+static int maxio_mae0621aq3ci_probe(struct phy_device *phydev)
+{
+	int *paras;
+	paras = kzalloc( 2 * sizeof(int), GFP_KERNEL);
+	if(!paras)
+		return -ENOMEM;
+
+	phydev->priv = paras;
+
+	printk("maxio_mae0621aQ3C probe PHY_ID: 0x%x\n", phydev->phy_id);
+
+	return 0;
+}
+
+static int maxio_mae0621aq3ci_config_init(struct phy_device *phydev)
+{
+	int ret = 0;
+	printk("MAXIO_PHY_VER: %s \n",MAXIO_PHY_VER);
+
+	ret |= maxio_write_paged(phydev, 0xa43, 0x19, 0x823);
+	ret |= maxio_write_paged(phydev, 0xdab, 0x17, 0xC13);
+	ret |= maxio_write_paged(phydev, 0xd96, 0x15, 0xc08a);
+	ret |= maxio_write_paged(phydev, 0xda4, 0x12, 0x7bc);
+	ret |= maxio_write_paged(phydev, 0xd8f, 0x16, 0x2500);
+	ret |= maxio_write_paged(phydev, 0xd90, 0x16, 0x1555);
+	ret |= maxio_write_paged(phydev, 0xd92, 0x11, 0x2b15);
+	ret |= maxio_write_paged(phydev, 0xd96, 0x16, 0x4010);
+	ret |= maxio_write_paged(phydev, 0xda5, 0x11, 0x4a12);
+	ret |= maxio_write_paged(phydev, 0xda5, 0x12, 0x4a12);
+	ret |= maxio_write_paged(phydev, 0xd99, 0x16, 0xa);
+	ret |= maxio_write_paged(phydev, 0xd95, 0x13, 0x5b00);
+	ret |= maxio_write_paged(phydev, 0xd8f, 0x10, 0x300);
+	ret |= maxio_write_paged(phydev, 0xd98, 0x17, 0x8506);
+	ret |= maxio_write_paged(phydev, 0xd95, 0x12, 0x6870);
+	ret |= maxio_write_paged(phydev, 0xd93, 0x15, 0x940);
+	ret |= maxio_write_paged(phydev, 0xdad, 0x12, 0x303);   // TXCST OFF
+	ret |= maxio_write_paged(phydev, 0xdad, 0x13, 0x50d);   // IO DS=1
+	ret |= maxio_write_paged(phydev, 0xdad, 0x14, 0xd05);
+	ret |= maxio_write_paged(phydev, 0xdad, 0x15, 0x505);
+	ret |= maxio_write_paged(phydev, 0xdad, 0x17, 0x1);
+	ret |= maxio_write_paged(phydev, 0xda8, 0x11, 0x177);
+	ret |= maxio_write_paged(phydev, 0xda8, 0x10, 0x9a9);
+	ret |= maxio_write_paged(phydev, 0xda8, 0x12, 0x868);
+	ret |= maxio_write_paged(phydev, 0xa42, 0x12, 0x28);
+	ret |= maxio_write_paged(phydev, 0x0, 0x4, 0xde1);
+	ret |= maxio_write_paged(phydev, 0x0, 0x0, 0x9140);
+
+	ret |= PHY_WRITE(phydev, MAXIO_PAGE_SELECT, 0);
+
+	return 0;
+}
+
+static int maxio_mae0621aq3ci_resume(struct phy_device *phydev)
+{
+	int ret = 0;
+	ret = genphy_resume(phydev);
+	ret |= maxio_write_paged(phydev, 0xdaa, 0x17, 0x1001 );
+	ret |= maxio_write_paged(phydev, 0xdab, 0x15, 0x0 );
+	ret |= PHY_WRITE(phydev, MAXIO_PAGE_SELECT, 0);
+
+	return ret;
+}
+
+static int maxio_mae0621aq3ci_suspend(struct phy_device *phydev)
+{
+	int ret = 0;
+
+	ret = maxio_write_paged(phydev, 0xdaa, 0x17, 0x1011 );
+	ret |= maxio_write_paged(phydev, 0xdab, 0x15, 0x5550 );
+	ret |= PHY_WRITE(phydev, MAXIO_PAGE_SELECT, 0);
+
+	ret |= genphy_suspend(phydev);
+
+	ret |= PHY_WRITE(phydev, MAXIO_PAGE_SELECT ,0);
+
+	return ret;
+}
+
+static struct phy_driver maxio_nc_drvs[] = {
+	{
+		.phy_id = 0x7b744411,
+		.phy_id_mask = 0x7fffffff,
+		.name = "MAE0621A-Q2C Gigabit Ethernet",
+		.features = PHY_GBIT_FEATURES,
+		.probe = maxio_mae0621a_probe,
+		.config_init	= maxio_mae0621a_config_init,
+		.config_aneg = &genphy_config_aneg,
+		.read_status = maxio_mae0621a_status,
+		.suspend = maxio_mae0621a_suspend,
+		.resume = maxio_mae0621a_resume,
+		.remove = maxio_mae0621a_remove,
+	},
+	{
+		.phy_id = 0x7b744412,
+		.phy_id_mask = 0x7fffffff,
+		.name = "MAE0621A/B-Q3C(I) Gigabit Ethernet",
+		.features = PHY_GBIT_FEATURES ,
+		.probe = maxio_mae0621aq3ci_probe,
+		.config_aneg = &genphy_config_aneg,
+		.config_init = maxio_mae0621aq3ci_config_init,
+		.read_status = &maxio_mae0621a_status,
+		.suspend = maxio_mae0621aq3ci_suspend,
+		.resume = maxio_mae0621aq3ci_resume,
+		.remove = maxio_mae0621a_remove,
+	},
+};
+
+module_phy_driver(maxio_nc_drvs);
+static struct mdio_device_id __maybe_unused maxio_nc_tbl[] = {
+	{ 0x7b744411, 0x7fffffff },
+	{ 0x7b744412, 0x7fffffff },
+	{ }
+};
+
+MODULE_DEVICE_TABLE(mdio, maxio_nc_tbl);
+
+MODULE_DESCRIPTION("Maxio PHY driver");
+MODULE_AUTHOR("Zhao Yang");
+MODULE_LICENSE("GPL");

--- a/drivers/net/phy/phy_device.c
+++ b/drivers/net/phy/phy_device.c
@@ -902,6 +902,16 @@ static int get_phy_c22_id(struct mii_bus *bus, int addr, u32 *phy_id)
 {
 	int phy_reg;
 
+#ifdef CONFIG_MAXIO_PHY
+	/*
+	 * An MDIO connects to multiple PHYs requiring write before read.
+	 * And this is also required for KICKPI K3B,
+	 * otherwise, the STMicro MAC will throw a DMA reset error.
+	 * MII_PHYSID2 is a read-only register and writine to it has no effect.
+	 */
+	mdiobus_write(bus, addr, MII_PHYSID2, 0);
+#endif
+
 	/* Grab the bits from PHYIR1, and put them in the upper half */
 	phy_reg = mdiobus_read(bus, addr, MII_PHYSID1);
 	if (phy_reg < 0) {


### PR DESCRIPTION
This PR adds kernel-level support for the RK3562 SBC KICKPI K3B. It mainly accomplishes the following:

1.Adds the base DTS for KICKPI K3B.

2.Adds a JD9366-based DSI panel DTB overlay for KICKPI K3B. Since the KICKPI K3B only features a DSI display interface, using a DTBO to support custom panels is a practical approach for users. The screen DTSO provided here is configured for my own panel and can be used as a reference.

3.Adds the I2C touch driver for JD9366. This is the TDDI touch driver for the panel I used, with the source code originating from JADARD.

4.Adds Panfrost support for the RK3562 Mali-G52 GPU. If the clk_gpu, clk_gpu_brg, and aclk_gpu clocks (declared in rk3562.dtsi) are not enabled, the kernel will hang during Panfrost initialization:

```
root@kickpi-k3b:~# modprobe panfrost
[ 2817.332173] panfrost ff320000.gpu: clock rate = 500000000
[ 2817.344151] panfrost ff320000.gpu: EM: created perf domain    <---- Stuck here
```

5.Adds the driver for the MAXIO PHY used by KICKPI K3B.

6.Introduces the `initial-on-delay-ms` property for gpio-leds. This property forces a specified delay before turning on LEDs that are configured to be "on" during the boot process. This is introduced to resolve a specific hardware quirk on the KICKPI K3B:
If the battery functionality is enabled in software but no physical battery is connected, powering the device via Type-C will cause it to hang during the boot process. To workaround this issue, KICKPI introduces a 10-second delay before enabling the USB Type-A power supply.