### PR TITLE
arm64: dts: rockchip: yy3588: drop non-existent SPI NOR flash

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-youyeetoo-yy3588.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-youyeetoo-yy3588.dts
@@ -905,37 +905,6 @@
 	vqmmc-supply = <&vccio_sd_s0>;
 };
 
-&sfc {
-	#address-cells = <1>;
-	#size-cells = <0>;
-	max-freq = <100000000>;
-	pinctrl-names = "default";
-	pinctrl-0 = <&fspim1_pins>;
-	status = "okay";
-
-	spi_flash: spi-flash@0 {
-		compatible = "jedec,spi-nor";
-		reg = <0x0>;
-		#address-cells = <1>;
-		#size-cells = <0>;
-		spi-max-frequency = <100000000>;
-		spi-rx-bus-width = <4>;
-		spi-tx-bus-width = <1>;
-		status = "okay";
-
-		partitions {
-			compatible = "fixed-partitions";
-			#address-cells = <1>;
-			#size-cells = <1>;
-
-			loader@0 {
-				label = "loader";
-				reg = <0x0 0x1000000>;
-			};
-		};
-	};
-};
-
 &spdif_tx2 {
 	status = "okay";
 };


### PR DESCRIPTION
The YY3588 device tree enables the SFC controller with a jedec,spi-nor node, but the board has no SPI NOR fitted. I checked the V3 schematic and there is no flash on the FSPI lines.

Because the SFC is enabled, its fspim1 pins collide with uart7 on gpio2-12. uart7 is wired and enabled, so the pin controller hands the pin to the serial and rejects the SFC, which then floods the log:

```
rockchip-pinctrl: pin gpio2-12 already requested by feba0000.serial; cannot claim for fe2b0000.spi
rockchip-sfc fe2b0000.spi: Error applying setting, reverse things back
```

Dropping the sfc override leaves the controller disabled, which is the SoC dtsi default, frees the pins for uart7, and clears the errors.

Tested on a YY3588 with the vendor kernel (6.1.115). armbianmonitor from before the fix: https://paste.armbian.com/dutitimenu
