### PR TITLE
drm/rockchip: dw-dp: ratelimit AUX timeout logging

### DIFF
--- a/drivers/gpu/drm/rockchip/dw-dp.c
+++ b/drivers/gpu/drm/rockchip/dw-dp.c
@@ -3182,8 +3182,8 @@ static ssize_t dw_dp_aux_transfer(struct drm_dp_aux *aux,
 		 * native AUX functionality for link training.
 		 */
 		if (retry == 0) {
-			dev_warn(dp->dev, "AUX timeout, resetting (cmd=0x%x addr=0x%x)\n",
-				 msg->request, msg->address);
+			dev_warn_ratelimited(dp->dev, "AUX timeout, resetting (cmd=0x%x addr=0x%x)\n",
+					     msg->request, msg->address);
 			regmap_update_bits(dp->regmap, DPTX_SOFT_RESET_CTRL,
 					   AUX_RESET, AUX_RESET);
 			usleep_range(10, 20);
@@ -3196,8 +3196,8 @@ static ssize_t dw_dp_aux_transfer(struct drm_dp_aux *aux,
 
 	if (!status) {
 		regmap_read(dp->regmap, DPTX_AUX_STATUS, &value);
-		dev_info(dp->dev, "AUX timeout after recovery: cmd=0x%x addr=0x%x size=%d, AUX_STATUS=0x%x\n",
-			 msg->request, msg->address, msg->size, value);
+		dev_dbg(dp->dev, "AUX timeout after recovery: cmd=0x%x addr=0x%x size=%d, AUX_STATUS=0x%x\n",
+			msg->request, msg->address, msg->size, value);
 		ret = -ETIMEDOUT;
 		goto out;
 	}


### PR DESCRIPTION
On a YY3588 the DP0 port is a USB-C DP Alt Mode output. With nothing plugged in, the boot log fills with about 128 lines from the AUX probe:

```
dw-dp fde50000.dp: AUX timeout, resetting (cmd=0x9 addr=0x0)
dw-dp fde50000.dp: AUX timeout after recovery: cmd=0x9 addr=0x0 size=1, AUX_STATUS=0x0
```

Every DPCD access times out because there is no sink, and each failed transfer logs one warning for the reset and one info line after recovery. Sixty-four failed transfers at boot means well over a hundred lines for a condition that is completely normal (no cable).

This ratelimits the reset warning and demotes the post-recovery message to debug. Callers already handle the returned -ETIMEDOUT, so nothing else changes.

Tested on a YY3588 (EVB7 V11, vendor kernel 6.1.115): the AUX flood drops from 128 lines to about 20 ratelimited warnings, and DP output on a connected sink is unaffected.
