### PR TITLE
rkr7.2: `clk: rk808: fix platform_device_id names for the clkout cells` + `regulator`, `rtc`, `pwrkey` cells

### DIFF
--- a/drivers/clk/clk-rk808.c
+++ b/drivers/clk/clk-rk808.c
@@ -201,11 +201,11 @@ static int rk808_clkout_probe(struct platform_device *pdev)
 }
 
 static const struct platform_device_id rk8xx_clk_id_table[] = {
-	{ "rk805-clk", 0 },
-	{ "rk809-clk", 0 },
-	{ "rk816-clk", 0 },
-	{ "rk817-clk", 0 },
-	{ "rk818-clk", 0 },
+	{ "rk805-clkout", 0 },
+	{ "rk808-clkout", 0 },
+	{ "rk816-clkout", 0 },
+	{ "rk817-clkout", 0 },
+	{ "rk818-clkout", 0 },
 	{ }
 };
 MODULE_DEVICE_TABLE(platform, rk8xx_clk_id_table);

--- a/drivers/input/misc/rk805-pwrkey.c
+++ b/drivers/input/misc/rk805-pwrkey.c
@@ -126,9 +126,9 @@ static int rk805_pwrkey_probe(struct platform_device *pdev)
 }
 
 static const struct platform_device_id rk8xx_pwrkey_id_table[] = {
+	{ "rk801-pwrkey", 0 },
 	{ "rk805-pwrkey", 0 },
 	{ "rk806-pwrkey", 0 },
-	{ "rk809-pwrkey", 0 },
 	{ "rk816-pwrkey", 0 },
 	{ "rk817-pwrkey", 0 },
 	{ "rk818-pwrkey", 0 },

--- a/drivers/regulator/rk808-regulator.c
+++ b/drivers/regulator/rk808-regulator.c
@@ -1779,7 +1779,7 @@ static int rk808_regulator_probe(struct platform_device *pdev)
 
 static const struct platform_device_id rk8xx_regulator_id_table[] = {
 	{ "rk805-regulator", 0 },
-	{ "rk809-regulator", 0 },
+	{ "rk808-regulator", 0 },
 	{ "rk816-regulator", 0 },
 	{ "rk817-regulator", 0 },
 	{ "rk818-regulator", 0 },

--- a/drivers/rtc/rtc-rk808.c
+++ b/drivers/rtc/rtc-rk808.c
@@ -492,7 +492,7 @@ static int rk808_rtc_probe(struct platform_device *pdev)
 
 static const struct platform_device_id rk8xx_rtc_id_table[] = {
 	{ "rk805-rtc", 0 },
-	{ "rk809-rtc", 0 },
+	{ "rk808-rtc", 0 },
 	{ "rk816-rtc", 0 },
 	{ "rk817-rtc", 0 },
 	{ "rk818-rtc", 0 },


### PR DESCRIPTION

> Few things that hadn't landed on previous rkr, plus a fix for _essentially every RK809/RK817 board with an SDIO WiFi module lost WiFi in rkr7.2_

---

#### clk: rk808: fix platform_device_id names for the clkout cells

Commit ea9b5acdc13b0 ("mfd: rk8xx: add multi-PMIC coexistence support for
rk8xx series") renamed the per-variant MFD cells and gave each child driver
a platform_device_id table to match on. The clkout table got the suffix
wrong: it lists "rk805-clk", "rk817-clk", ... while rk808.c registers the
platform devices as "rk805-clkout", "rk817-clkout", ...

No entry matches a real device, and the driver name does not save it either.
platform_match() returns as soon as a driver has an id_table:

    if (pdrv->id_table)
        return platform_match_id(pdrv->id_table, pdev) != NULL;

    /* fall-back to driver name match */
    return (strcmp(pdev->name, drv->name) == 0);

so introducing the table also stopped "rk808-clkout" from matching the
driver's own name, which is how it used to bind. rk808_clkout_probe()
therefore never runs on any variant, RK808 included, and the PMIC registers
no clock provider at all.

Every consumer of <&rk8xx 1> then gets -EPROBE_DEFER forever. On boards with
an SDIO WiFi module that means mmc-pwrseq-simple never probes, so the SDIO
host never gets a pwrseq and never enumerates the card:

  [WLAN_RFKILL]: wlan_platdata_parse_dt: The ref_wifi_clk not found !
  platform sdio-pwrseq: deferred probe pending
  dwmmc_rockchip fe000000.mmc: <re-probed indefinitely, no mmc host>

Before that commit there was no id_table and every variant used the
"rk808-clkout" cell name, so all of them bound via the driver name. That is
why this only shows up now.

Fix the table to use the device names rk808.c actually creates. RK801 has no
clkout cell, so it is intentionally absent.

---

### mfd: rk8xx: fix platform_device_id names for the regulator, rtc and pwrkey cells

Same class of bug as the clkout table: the id tables added by ea9b5acdc13b0
("mfd: rk8xx: add multi-PMIC coexistence support for rk8xx series") list
device names that rk808.c never creates, while omitting names it does.

RK809 shares the rk817s[] cell array with RK817 (see the RK809_ID/RK817_ID
fallthrough in rk808_probe()), so the platform devices are called
"rk817-regulator", "rk817-rtc" and "rk817-pwrkey". There is no such thing as
an "rk809-*" device, making those three entries permanently dead. Conversely
"rk808-regulator" and "rk808-rtc" are created by rk808s[] but are in no
table, and "rk801-pwrkey" is created by rk801s[] but is in no table.

This is not cosmetic. platform_match() returns as soon as a driver has an
id_table:

    if (pdrv->id_table)
        return platform_match_id(pdrv->id_table, pdev) != NULL;

    /* fall-back to driver name match */
    return (strcmp(pdev->name, drv->name) == 0);

so once these tables exist the drv->name fallback is unreachable, and a
device missing from the table binds to nothing at all. RK808 boards
therefore come up with no regulators and no RTC, and RK801 boards with no
power key.

Replace the impossible rk809-* entries with the names that are actually
missing. rk801-regulator needs no entry: it is handled by its own driver in
drivers/regulator/rk801-regulator.c, which has no id_table and so still
matches by name.

---

Assisted-by: Claude Opus 5

