### PR TITLE
rkr7.2: fixup RGA3 flickering pixels during upscaling

### DIFF
--- a/drivers/video/rockchip/rga3/rga3_reg_info.c
+++ b/drivers/video/rockchip/rga3/rga3_reg_info.c
@@ -2157,7 +2157,7 @@ static int rga3_set_reg(struct rga_job *job, struct rga_scheduler_t *scheduler)
 		rga3_dump_read_back_iommu_reg(job, scheduler);
 	}
 
-	sys_ctrl = m_RGA3_SYS_CTRL_RGA_LGC_CLK_ON | m_RGA3_SYS_CTRL_FRMEND_AUTO_RSTN_EN;
+	sys_ctrl = m_RGA3_SYS_CTRL_FRMEND_AUTO_RSTN_EN;
 
 	/* All CMD finish int */
 	if (master_mode_en)


### PR DESCRIPTION
Revert "video: rockchip: rga3: enable RGA3 logic_clk_on on RK3588"

It can cause flickering pixels along image edges during upscaling.

This reverts commit 6cddb8da052cd9b943e823159894f64c5f342ca8.