### PR TITLE
rkr7.2: fix 32-bit build (`arm: dts: drop rv1126b-evb1-v12-4x-cam.dts`)

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -1199,7 +1199,6 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
 	rv1126b-evb1-v12-spi-nand.dtb \
 	rv1126b-evb1-v12-uvc.dtb \
 	rv1126b-evb1-v12-uvc-winhello.dtb \
-	rv1126b-evb1-v12-4x-cam.dts \
 	rv1126b-evb2-v10.dtb \
 	rv1126b-evb2-v10-dv.dtb \
 	rv1126b-evb2-v10-mcu-k350c4516t.dtb \


### PR DESCRIPTION
#### rkr7.2: fix 32-bit build (`arm: dts: drop rv1126b-evb1-v12-4x-cam.dts`)