### PR TITLE
rkr7.2: Revert "ARM: dts: rockchip: add rv1126b-evb1-v12-4x-cam.dts"

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -1199,7 +1199,6 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += \
 	rv1126b-evb1-v12-spi-nand.dtb \
 	rv1126b-evb1-v12-uvc.dtb \
 	rv1126b-evb1-v12-uvc-winhello.dtb \
-	rv1126b-evb1-v12-4x-cam.dts \
 	rv1126b-evb2-v10.dtb \
 	rv1126b-evb2-v10-dv.dtb \
 	rv1126b-evb2-v10-mcu-k350c4516t.dtb \

--- a/arch/arm/boot/dts/rv1126b-evb1-v12-4x-cam.dts
+++ b/arch/arm/boot/dts/rv1126b-evb1-v12-4x-cam.dts
@@ -1,7 +1,0 @@
-// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
-/*
- * Copyright (c) 2025 Rockchip Electronics Co., Ltd.
- */
-
-#include "arm64/rockchip/rv1126b-evb1-v12-4x-cam.dts"
-


### PR DESCRIPTION
Followup to #520 rkr7.2: fix 32-bit build (arm: dts: drop rv1126b-evb1-v12-4x-cam.dts)

This reverts commit 18d0ea831815b38663883e2f9b58502da11e7faa.