### PR TITLE
input: rockchip_pwm_remotectl: fix IRQ selection and sharing on PWM v1

### DIFF
--- a/drivers/input/remotectl/rockchip_pwm_remotectl.c
+++ b/drivers/input/remotectl/rockchip_pwm_remotectl.c
@@ -513,11 +513,19 @@ static int rockchip_pwm_set_pwrmatch(struct platform_device *pdev)
 		goto end;
 	}
 	ret = devm_request_irq(&pdev->dev, pwr_irq, rockchip_pwm_pwrirq,
-			IRQF_NO_SUSPEND, "rk_pwm_pwr_irq", ddata);
+			IRQF_NO_SUSPEND | IRQF_SHARED, "rk_pwm_pwr_irq", ddata);
 	if (ret) {
 		dev_err(&pdev->dev, "cannot claim PWR_IRQ!!!\n");
 		goto end;
 	}
+	/*
+	 * remotectl_suspend() masks the capture channel and leaves
+	 * PWM_PWR_INT_ENABLE set, so the power key arrives here rather than on
+	 * the capture IRQ that probe arms for wake. IRQF_NO_SUSPEND keeps this
+	 * one delivered but does not make it a wake source, so mark it too.
+	 */
+	if (enable_irq_wake(pwr_irq))
+		dev_warn(&pdev->dev, "cannot set PWR_IRQ as wake source\n");
 	val = readl_relaxed(ddata->base + PWM_REG_INT_EN(pwm_id));
 	val = (val & 0xFFFFFF7F) | PWM_PWR_INT_ENABLE;
 	writel_relaxed(val, ddata->base + PWM_REG_INT_EN(pwm_id));
@@ -938,10 +946,13 @@ static int rk_pwm_probe(struct platform_device *pdev)
 	 * with the other channels in the same PWM controller. Prefer the
 	 * dedicated one so we don't collide with the pwm-rockchip driver
 	 * bound to another channel (which claims the group IRQ without
-	 * IRQF_SHARED on v4). Fall back to index 0 for older PWM v1-v3.
+	 * IRQF_SHARED on v4). On v1 index 1 is the pwrmatch IRQ instead and
+	 * capture lives on the group IRQ, so select by version, not by probe
+	 * failure - the index 1 lookup succeeds there and returns the wrong line.
 	 */
-	irq = platform_get_irq(pdev, 1);
-	if (irq < 0)
+	if (ddata->pwm_data->pwm_version >= 4)
+		irq = platform_get_irq(pdev, 1);
+	else
 		irq = platform_get_irq(pdev, 0);
 	if (irq < 0) {
 		dev_err(&pdev->dev, "cannot find IRQ\n");
@@ -988,7 +999,7 @@ static int rk_pwm_probe(struct platform_device *pdev)
 	cpumask_set_cpu(cpu_id, &cpumask);
 	irq_set_affinity_hint(irq, &cpumask);
 	ret = devm_request_irq(&pdev->dev, irq, ddata->pwm_data->funcs.irq_handler,
-			       IRQF_NO_SUSPEND, "rk_pwm_irq", ddata);
+			       IRQF_NO_SUSPEND | IRQF_SHARED, "rk_pwm_irq", ddata);
 	if (ret) {
 		dev_err(&pdev->dev, "cannot claim IRQ %d\n", irq);
 		goto error_irq;


### PR DESCRIPTION
Follow-up to #503, which is correct on v4 but not on v1.

**Wrong IRQ.** The code takes `platform_get_irq(pdev, 1)` and falls back to index 0
on failure. On v4 index 1 is channel 3's dedicated capture IRQ; on v1 it is the
pwrmatch IRQ and capture lives on the group IRQ at index 0. The lookup succeeds on
v1, so the fallback never runs — `irq 28: nobody cared`. Select by `pwm_version`;
the driver defines only 1 and 4.

**Non-shared request.** On v1 the group IRQ is shared with the other channels, and
`pwm-rockchip` claims it `IRQF_NO_SUSPEND | IRQF_SHARED` for `main_version < 4`, so
a non-shared request is refused. Both handlers already read `PWM_REG_INTSTS` and
return `IRQ_NONE`, so sharing is safe.

**Wake source.** Moving capture to index 0 also moves what `enable_irq_wake()` arms,
but the power key arrives on pwrmatch — `remotectl_suspend()` masks the capture
channel and leaves `PWM_PWR_INT_ENABLE` set. `pwr_irq` is now marked too.

Verified on an RK3528 box:

```
irq 28  rk_pwm_irq ×4    wakeup=enabled   (group, shared with pwm-rockchip)
irq 57  rk_pwm_pwr_irq   wakeup=enabled   (pwrmatch)
```

Receiver enumerates as `event2`, every remote button produces key events, the power
key cold-boots from off, no `nobody cared` and no flags mismatch. Not covered:
resume from s2idle — deep-suspend wake on this SoC goes through PSCI/PMU. No change
on v4.
