### PR TITLE
net: stmmac: don't put an absent MDIO reset GPIO

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_mdio.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_mdio.c
@@ -359,7 +359,8 @@ int stmmac_mdio_idle(struct mii_bus *bus)
 		if (IS_ERR(reset_gpio))
 			return PTR_ERR(reset_gpio);
 
-		devm_gpiod_put(priv->device, reset_gpio);
+		if (reset_gpio)
+			devm_gpiod_put(priv->device, reset_gpio);
 	}
 #endif
 #endif
@@ -405,7 +406,8 @@ int stmmac_mdio_reset(struct mii_bus *bus)
 			msleep(DIV_ROUND_UP(delays[2], 1000));
 
 		/* put reset gpio resource for next time */
-		devm_gpiod_put(priv->device, reset_gpio);
+		if (reset_gpio)
+			devm_gpiod_put(priv->device, reset_gpio);
 	}
 #endif
 


### PR DESCRIPTION
`devm_gpiod_get_optional()` returns NULL when the property is absent, but both call
sites only test `IS_ERR()` before `devm_gpiod_put()`. Putting NULL means
`devres_release()` finds nothing, returns `-ENOENT`, and the `WARN_ON` inside
`devm_gpiod_put()` fires on every probe:

```
WARNING: CPU: 1 PID: 1 at drivers/gpio/gpiolib-devres.c:327 devm_gpiod_put+0x34/0x44
 devm_gpiod_put → stmmac_mdio_reset → __mdiobus_register
```

Only three device trees in this repo set `snps,reset`, so most Rockchip boards with
an integrated PHY take the NULL path. `gpiod_set_value_cansleep()` already tolerates
NULL, so only the two puts need guarding.

Verified on an RK3528 board: MDIO registers (`stmmac-0:02`), `end0` comes up, warning
gone.
