### PR TITLE
net: wireless: rockchip_wlan: bcmdhd: build SDIO and PCIe as two modules

### DIFF
--- a/drivers/net/wireless/rockchip_wlan/rkwifi/Kconfig
+++ b/drivers/net/wireless/rockchip_wlan/rkwifi/Kconfig
@@ -2,6 +2,10 @@
 config AP6XXX
 	tristate "ap6xxx wireless cards support"
 	depends on RFKILL_RK
+	# The SDIO and PCIe back-ends both define the same dhd_bus_*/dhd_prot_*
+	# symbols, so supporting both at once means building two separate
+	# modules, which rules out a built-in driver.
+	depends on !(BCMDHD_SDIO && BCMDHD_PCIE) || m
 	select CFG80211
 	select MAC80211
 	help
@@ -13,22 +17,28 @@ config AP6XXX
 	  If you choose to build a module, it'll be called dhd. Say M if
 	  unsure.
 
-choice
-	prompt "Enable Chip Interface"
+comment "Enable Chip Interface"
 	depends on BCMDHD
-	default BCMDHD_SDIO
-	help
-	  Enable Chip Interface.
 
 config BCMDHD_SDIO
 	bool "SDIO bus interface support"
 	depends on BCMDHD && MMC
+	# This used to be a choice defaulting to SDIO, so configs that select
+	# neither must keep getting SDIO, while configs that ask for PCIe only
+	# must not silently gain a second module.
+	default y if !BCMDHD_PCIE
+	help
+	  Build the SDIO bus back-end.  Selecting this together with
+	  BCMDHD_PCIE builds two independent modules, dhdsdio.ko and
+	  dhdpcie.ko, so that one kernel can serve both kinds of board.
 
 config BCMDHD_PCIE
 	bool "PCIe bus interface support"
 	depends on BCMDHD && PCI
-
-endchoice
+	help
+	  Build the PCIe bus back-end.  Selecting this together with
+	  BCMDHD_SDIO builds two independent modules, dhdsdio.ko and
+	  dhdpcie.ko, so that one kernel can serve both kinds of board.
 
 config PCIEASPM_ROCKCHIP_WIFI_EXTENSION
 	bool "Extend ASPM function"

--- a/drivers/net/wireless/rockchip_wlan/rkwifi/Makefile
+++ b/drivers/net/wireless/rockchip_wlan/rkwifi/Makefile
@@ -2,7 +2,13 @@
 #rkwifi packed Makefile
 # (gwl)
 
-obj-$(CONFIG_AP6XXX) += bcmdhd/
+# The bcmdhd sources in bcmdhd/ are bus-agnostic only in name: the bus is
+# picked by -D flags that leak into every shared file, and dhd_sdio.c and
+# dhd_pcie.c define the same dhd_bus_*/dhd_prot_* symbols.  So each bus gets
+# its own object directory, which compiles the shared sources with its own
+# flag set into its own module.  bcmdhd/ itself is never built directly.
+obj-$(CONFIG_BCMDHD_SDIO) += bcmdhd_sdio/
+obj-$(CONFIG_BCMDHD_PCIE) += bcmdhd_pcie/
 
 .PHONY: clean
 

--- a/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd/Makefile
+++ b/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd/Makefile
@@ -472,7 +472,9 @@ endif
 endif
 
 ARCH ?= arm64
-BCMDHD_ROOT = $(src)
+# Overridable so that the per-bus object directories (../bcmdhd_sdio,
+# ../bcmdhd_pcie) can point this back at the shared sources.
+BCMDHD_ROOT ?= $(src)
 #$(warning "BCMDHD_ROOT=$(BCMDHD_ROOT)")
 EXTRA_CFLAGS = $(DHDCFLAGS)
 EXTRA_CFLAGS += -DDHD_COMPILED=\"$(BCMDHD_ROOT)\"

--- a/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd_pcie/Makefile
+++ b/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd_pcie/Makefile
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# PCIe instance of the shared bcmdhd sources.
+#
+# bcmdhd selects its bus with -D flags that reach into every shared file, and
+# dhd_sdio.c and dhd_pcie.c define the same dhd_bus_*/dhd_prot_* symbols, so a
+# single module can only ever serve one bus.  To let one kernel serve both
+# kinds of board, the sources in ../bcmdhd are compiled once per bus, with the
+# objects landing in this directory so the two flag sets cannot collide.
+
+BCMDHD_ROOT := $(src)/../bcmdhd
+
+# Use the vendor's multi-driver naming (dhdsdio.ko / dhdpcie.ko, plus a
+# per-bus log prefix and sysfs name) only when both back-ends are actually
+# being built.  A single-bus config keeps producing plain bcmdhd.ko, exactly
+# as it did before.
+ifeq ($(CONFIG_BCMDHD_SDIO)$(CONFIG_BCMDHD_PCIE),yy)
+CONFIG_BCMDHD_MULTIPLE_DRIVER := y
+endif
+
+# Pin this instance to a single bus, whatever the .config selected.
+CONFIG_BCMDHD_SDIO :=
+CONFIG_BCMDHD_PCIE := y
+CONFIG_BCMDHD_USB  :=
+
+include $(srctree)/$(BCMDHD_ROOT)/Makefile
+
+# The sources live in ../bcmdhd, so kbuild's built-in $(obj)/%.o: $(src)/%.c
+# rule cannot find them.
+$(obj)/%.o: $(srctree)/$(BCMDHD_ROOT)/%.c FORCE
+	$(call if_changed_rule,cc_o_c)

--- a/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd_sdio/Makefile
+++ b/drivers/net/wireless/rockchip_wlan/rkwifi/bcmdhd_sdio/Makefile
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# SDIO instance of the shared bcmdhd sources.
+#
+# bcmdhd selects its bus with -D flags that reach into every shared file, and
+# dhd_sdio.c and dhd_pcie.c define the same dhd_bus_*/dhd_prot_* symbols, so a
+# single module can only ever serve one bus.  To let one kernel serve both
+# kinds of board, the sources in ../bcmdhd are compiled once per bus, with the
+# objects landing in this directory so the two flag sets cannot collide.
+
+BCMDHD_ROOT := $(src)/../bcmdhd
+
+# Use the vendor's multi-driver naming (dhdsdio.ko / dhdpcie.ko, plus a
+# per-bus log prefix and sysfs name) only when both back-ends are actually
+# being built.  A single-bus config keeps producing plain bcmdhd.ko, exactly
+# as it did before.
+ifeq ($(CONFIG_BCMDHD_SDIO)$(CONFIG_BCMDHD_PCIE),yy)
+CONFIG_BCMDHD_MULTIPLE_DRIVER := y
+endif
+
+# Pin this instance to a single bus, whatever the .config selected.
+CONFIG_BCMDHD_SDIO := y
+CONFIG_BCMDHD_PCIE :=
+CONFIG_BCMDHD_USB  :=
+
+include $(srctree)/$(BCMDHD_ROOT)/Makefile
+
+# The sources live in ../bcmdhd, so kbuild's built-in $(obj)/%.o: $(src)/%.c
+# rule cannot find them.
+$(obj)/%.o: $(srctree)/$(BCMDHD_ROOT)/%.c FORCE
+	$(call if_changed_rule,cc_o_c)


### PR DESCRIPTION
#### net: wireless: rockchip_wlan: bcmdhd: build SDIO and PCIe as two modules

BCMDHD_SDIO and BCMDHD_PCIE were mutually exclusive members of a Kconfig
choice, so a single kernel could only ever serve one kind of Broadcom
wireless board. That is not policy but a property of the driver: dhd_sdio.c
and dhd_pcie.c both define the same abstract bus API declared in dhd_bus.h
(dhd_bus_register(), dhd_bus_init(), dhd_prot_attach() and 56 more), each
defines its own incompatible struct dhd_bus, and the bus is picked by -D
flags that reach into every shared file. PCIE_FULL_DONGLE alone changes the
dhd_pub_t layout and the TX path in dhd_linux.c.

So one module cannot serve both buses without rewriting the bus layer. Two
modules can, and no board carries both a PCIe and an SDIO Broadcom part, so
that is enough to let one kernel and one .config cover both.

Compile the shared sources once per bus into a per-bus object directory.
Each directory pins CONFIG_BCMDHD_{SDIO,PCIE,USB} locally, includes the
existing bcmdhd Makefile to derive its own flag and object set, and supplies
a pattern rule that builds ../bcmdhd/%.c into its own %.o so the two flag
sets cannot collide. bcmdhd/ itself is no longer built directly, and only
needs BCMDHD_ROOT made overridable so the include path still resolves.

When both back-ends are selected, turn on the vendor's existing
CONFIG_BCMDHD_MULTIPLE_DRIVER, which names the modules dhdsdio.ko and
dhdpcie.ko and gives each a distinct log prefix and sysfs name. A config
that selects one bus is left completely alone: it still produces bcmdhd.ko
with BUS_TYPE="" and no BCMDHD_MDRIVER, and can still be built in.

Building both requires modules, since two copies of those 59 symbols cannot
be linked into vmlinux, so cap AP6XXX at m in that case. BCMDHD_SDIO keeps
the choice's old default via "default y if !BCMDHD_PCIE", so configs that
selected neither, such as rockchip_linux_defconfig, still get SDIO.

Verified by cross-building arm64 with rockchip_linux_defconfig: the dual-bus
config yields dhdsdio.ko and dhdpcie.ko with no flag bleed between them and
no exported symbols in either, so both can be loaded at once; the PCI and
SDIO module aliases land in the right module for udev. rk3576_aibox,
rk3588_linux, rk3588_ipc_linux and rk3588_edge all resolve and build exactly
as before. Not yet tested on hardware.

Assisted-by: Claude Opus 5 <noreply@anthropic.com>