### PR TITLE
arm64: dts: rockchip: youyeetoo-r1: fix PCIe reset gpio and drop spi0 stub

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-yyt-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-yyt-common.dtsi
@@ -761,7 +761,7 @@
 };
 
 &pcie2x1l1 {
-	reset-gpios = <&gpio1 RK_PA7 GPIO_ACTIVE_HIGH>;
+	reset-gpios = <&gpio1 RK_PB0 GPIO_ACTIVE_HIGH>;
 	rockchip,init-delay-ms = <100>;
 	vpcie3v3-supply = <&vcc_3v3_pcie20>;
 	status = "okay";

--- a/arch/arm64/boot/dts/rockchip/rk3588s-yyt-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-yyt-common.dtsi
@@ -864,21 +864,6 @@
 	clock-names = "hdmi0_phy_pll";
 };
 
-/* SPI */
-
-&spi0 {
-	status = "okay";
-	pinctrl-names = "default";
-	pinctrl-0 = <&spi0m3_cs0  &spi0m3_cs1 &spi0m3_pins>;
-	num-cs = <2>;
-	spi_test@0 {
-		compatible = "rockchip,spi_test_bus0_cs1";
-		reg = <0>;
-		spi-max-frequency = <5000000>;
-	};
-};
-
-
 &spi2 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&spi2m2_cs0 &spi2m2_pins>;


### PR DESCRIPTION
The Youyeetoo R1 v3 device tree points the M.2 reset line at the wrong pin and enables an spi0 node that only ever instantiated a Rockchip debug stub. Both date back to the initial board submission and neither matches the V3 schematic.

pcie2x1l1 is the controller behind the M.2 M-key socket. Its reset-gpios names GPIO1_A7, but PERST# on connector pin 50 runs through R211 to GPIO1_B0. GPIO1_A7 is the SoC PCIE20X1_1_PERSTN_M2 alternate function pin, which is likely why it was picked, but on this board it is routed to pin 13 of the 30-pin user header instead. The driver has been toggling a header pin on every boot and resume while the card never sees a reset pulse.

The spi0 node claims the m3 pin group, and one of those pads is GPIO3_D1, which the schematic assigns to the mini-PCIe PERST# line. The pin controller settles the clash in favor of the PCIe driver and prints a warning with a backtrace on every boot, leaving spi0 without a MISO line. The board has no SPI NOR fitted and the only child was the EVB test stub, so the node has nothing left to do.

Tested on an R1 v3 with a Patriot P300 NVMe in the M.2 socket. To be clear about scope, this does not change whether the SSD is detected: the link comes up Gen2 x1 either way, because the module releases PERST# on its own at power-up. It is a correctness fix, and it stops the kernel from driving a user header pin. The pin assignments come from the V3 schematic cross checked against the pin tables in rk3588s-pinctrl.dtsi. The mainline device tree for this board carries the same wrong reset pin and I will send that fix separately.
