### PR TITLE
fix the thermal governor and pwm fan driver, as well as pwm frequency in Rock 5B/5B Plus/5T

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
@@ -30,7 +30,7 @@
 		compatible = "pwm-fan";
 		#cooling-cells = <2>;
 		cooling-levels = <0 64 128 192 255>;
-		pwms = <&pwm1 0 60000 0>;
+		pwms = <&pwm1 0 25000 0>;
 	};
 
 	vcc12v_dcin: vcc12v-dcin {

--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
@@ -29,8 +29,8 @@
 	fan0: pwm-fan {
 		compatible = "pwm-fan";
 		#cooling-cells = <2>;
-		cooling-levels = <0 64 128 192 255>;
-		pwms = <&pwm1 0 60000 0>;
+		cooling-levels = <0 128 146 164 182 201 219 237 255>;
+		pwms = <&pwm1 0 25000 0>;
 	};
 
 	vcc12v_dcin: vcc12v-dcin {

--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
@@ -30,7 +30,7 @@
 		compatible = "pwm-fan";
 		#cooling-cells = <2>;
 		cooling-levels = <0 64 128 192 255>;
-		pwms = <&pwm1 0 60000 0>;
+		pwms = <&pwm1 0 25000 0>;
 	};
 
 	vcc12v_dcin: vcc12v-dcin {

--- a/drivers/hwmon/pwm-fan.c
+++ b/drivers/hwmon/pwm-fan.c
@@ -519,13 +519,26 @@ static int pwm_fan_get_thermal_trips(struct device *dev, char *porp_name,
 	return 0;
 }
 
+/*
+ * Prevent constant speed hunting.
+ */
+#define PWM_FAN_TEMP_HYST	2000	/* millicelsius */
+
 static int pwm_fan_temp_to_state(struct pwm_fan_ctx *ctx, int temp)
 {
 	struct thermal_trips *trips = ctx->thermal_trips;
 	int i, state = 0;
 
 	for (i = 0; trips[i].state != INT_MAX; i++) {
-		if (temp >= trips[i].temp)
+		int trip_temp = trips[i].temp;
+
+		/*
+		 * Only trips at or below the state we currently occupy.
+		 */
+		if (trips[i].state <= ctx->pwm_fan_state)
+			trip_temp -= PWM_FAN_TEMP_HYST;
+
+		if (temp >= trip_temp)
 			state = trips[i].state;
 	}
 

--- a/drivers/thermal/gov_step_wise.c
+++ b/drivers/thermal/gov_step_wise.c
@@ -97,7 +97,7 @@ static void update_passive_instance(struct thermal_zone_device *tz,
 
 static void thermal_zone_trip_update(struct thermal_zone_device *tz, int trip)
 {
-	int trip_temp;
+	int trip_temp, hyst = 0;
 	enum thermal_trip_type trip_type;
 	enum thermal_trend trend;
 	struct thermal_instance *instance;
@@ -106,12 +106,26 @@ static void thermal_zone_trip_update(struct thermal_zone_device *tz, int trip)
 
 	tz->ops->get_trip_temp(tz, trip, &trip_temp);
 	tz->ops->get_trip_type(tz, trip, &trip_type);
+	if (tz->ops->get_trip_hyst)
+		tz->ops->get_trip_hyst(tz, trip, &hyst);
 
 	trend = get_tz_trend(tz, trip);
 
+	/*
+	 * A trip engages at its temperature and only disengages once the zone
+	 * has cooled a full hysteresis band below it. With no hysteresis configured
+	 * this reduces to the previous behaviour, releasing the trip as soon as
+	 * the temperature drops below it.
+	 */
 	if (tz->temperature >= trip_temp) {
+		set_bit(trip, &tz->trips_engaged);
 		throttle = true;
 		trace_thermal_zone_trip(tz, trip, trip_type);
+	} else if (tz->temperature >= trip_temp - hyst &&
+		   test_bit(trip, &tz->trips_engaged)) {
+		throttle = true;
+	} else {
+		clear_bit(trip, &tz->trips_engaged);
 	}
 
 	dev_dbg(&tz->device, "Trip%d[type=%d,temp=%d]:trend=%d,throttle=%d\n",

--- a/include/linux/thermal.h
+++ b/include/linux/thermal.h
@@ -125,6 +125,7 @@ struct thermal_cooling_device {
  * @trips:	an array of struct thermal_trip
  * @num_trips:	number of trip points the thermal zone supports
  * @trips_disabled;	bitmap for disabled trips
+ * @trips_engaged:	bitmap of trips currently holding their hysteresis band
  * @passive_delay_jiffies: number of jiffies to wait between polls when
  *			performing passive cooling.
  * @polling_delay_jiffies: number of jiffies to wait between polls when
@@ -166,6 +167,7 @@ struct thermal_zone_device {
 	struct thermal_trip *trips;
 	int num_trips;
 	unsigned long trips_disabled;	/* bitmap for disabled trips */
+	unsigned long trips_engaged;	/* bitmap for engaged trips */
 	unsigned long passive_delay_jiffies;
 	unsigned long polling_delay_jiffies;
 	int temperature;


### PR DESCRIPTION
This PR is the effect of my long battle with the default PWM fan on Rock 5B. The 2 °C hysteresis is debatable, I think it can be larger, please comment.

In short, the fan driver was broken from the beginning: 
- the hysteresis did not work correctly (it was programmed to be 5 degrees, with a 5 degree step - this _never_ worked, the fan just jumped up and down at every trip point)
- PWM switching resulted in constant sound similar to coil whine

With Claude's help I now identified the source of these issues. First: the "coil whine" was caused by the PWM frequency set: it was 16.67 kHz. This is within the human hearing range, so when the board used this, it meant a "bzz bzz bzzzzz" sound at most duty cycles (except those that were silent by chance). Even worse, with mechanical wear, the "silent" frequencies were moving, so it needed recalibrating periodically. This was fixed by changing the frequency to 40 kHz, well above the hearing range.

As for hysteresis, the `step_wise` governor just ignored it happily. Fixed in `pwm-fan.c` and `gov_step_wise.c`.

I could only test the PWM frequency fix as I cannot install a custom kernel on my Rock 5B right now. Please verify, but in general, there seems to be nothing wrong with the code. If someone can test this, please do.

I also found that the thermal ladder in the Rock 5B DTS has the wrong number of steps, corrected here. Separately, issues exist with these ladders in 5B Plus and 5T. I will paste Claude's findings here which I cannot verify as I don't have them:

> Those two boards define zero trips of their own. They hang the fan off the two passive trips inherited from `rk3588s.dtsi` — 75 °C and 85 °C. There is no trip below 75 °C, so under `step_wise` the fan sits at state 0, duty 0, fan stopped, until the SoC hits 75 °C — which is exactly where CPU passive throttling starts.

## Separate issues

A separate issue is the location of these trip points, and the design of the fan curve in general. These are very small devices with very low power. Consequently, their fans are small as well and they do not make much noise. The current ladder starts the fan at 45 degrees. This is a temperature these CPUs are **guaranteed** to hit without active cooling, so the only thing it does in practice is to make the fan start and stop for no reason. It seems that these ladders were designed for high power devices, which radiate enough heat to actually hit high temperatures, even with active cooling. **We are not dealing with such devices here.**

Then, the higher parts of the ladder. With _any_ active cooling, even modest, these SOCs certainly do not hit _any_ of the higher steps (except in super extreme conditions like running them at 70 degrees ambient - but in those, a custom fan setting is needed anyway).

A sensible way to resolve it would be:

- run the fan at a low (but not extremely low) speed at temps up to about 55 degrees (from, say, 25). Do not select the speed at which the fan barely moves, as it moves **no air** and is ineffective. Select a silent speed which actually does something.
- have a tighter ladder but with a lot of leeway at the bottom, for example: 55→63→67→71→75→80. The upper steps do not actually matter, as with any airflow, the SOC will almost never exceed 63 degrees. We have 31 steps at a maximum, so an almost linear "ladder" could be build.

In my case, the low speed with 40 kHz pwm, the three first speeds are: 149, 155, 161. The audible speed with this fan (Radxa 4012) is above ~164. The next trip point is 167, still very quiet, and _never_ achieved, at least in my experience (I cooked the board with `stress-ng`).

Another separate issue is that there are other boards with pwm-fan frequency below 40 kHz. I cannot test these.

Please consider this PR seriously, I've been fighting with this fan for years and it turns out the solution was there.