### PR TITLE
rock 5b/5bp/5t: raise fan PWM to 40 kHz, outside of the hearing range

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b-plus.dts
@@ -30,7 +30,7 @@
 		compatible = "pwm-fan";
 		#cooling-cells = <2>;
 		cooling-levels = <0 64 128 192 255>;
-		pwms = <&pwm1 0 60000 0>;
+		pwms = <&pwm1 0 25000 0>;
 	};
 
 	vcc12v_dcin: vcc12v-dcin {

--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5b.dts
@@ -29,8 +29,8 @@
 	fan0: pwm-fan {
 		compatible = "pwm-fan";
 		#cooling-cells = <2>;
-		cooling-levels = <0 64 128 192 255>;
-		pwms = <&pwm1 0 60000 0>;
+		cooling-levels = <0 128 146 164 182 201 219 237 255>;
+		pwms = <&pwm1 0 25000 0>;
 	};
 
 	vcc12v_dcin: vcc12v-dcin {

--- a/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-rock-5t.dts
@@ -30,7 +30,7 @@
 		compatible = "pwm-fan";
 		#cooling-cells = <2>;
 		cooling-levels = <0 64 128 192 255>;
-		pwms = <&pwm1 0 60000 0>;
+		pwms = <&pwm1 0 25000 0>;
 	};
 
 	vcc12v_dcin: vcc12v-dcin {


### PR DESCRIPTION
Narrower than #532 (closed, intentionally split). For a detailed description see that PR. 16.67 kHz makes the fan produce an annoying buzz all the time, so change it to 40 kHz. 

Additionally, fix the cooling levels on Rock 5B.

Personally, I am now running this:

```
/ {
        fragment@0 {
                target = <&fan0>;
                __overlay__ {
                        pwms = <&pwm1 0 25000 0>;
                        /*      <25   55   59   63   67   71   75   80 C */
                        cooling-levels = <149 149 155 161 167 180 205 230 255>;
                };
        };

        /* floor: below this the fan still runs at 149, so it never stops */
        fragment@1 {
                target = <&trip0>;
                __overlay__ {
                        temperature = <25000>;
                        hysteresis = <3000>;
                };
        };

        fragment@2 {
                target = <&trip1>;
                __overlay__ {
                        temperature = <55000>;
                        hysteresis = <3000>;
                };
        };

        fragment@3 {
                target = <&trip2>;
                __overlay__ {
                        temperature = <59000>;
                        hysteresis = <3000>;
                };
        };

        fragment@4 {
                target = <&trip3>;
                __overlay__ {
                        temperature = <63000>;
                        hysteresis = <3000>;
                };
        };

        fragment@5 {
                target = <&trip4>;
                __overlay__ {
                        temperature = <67000>;
                        hysteresis = <3000>;
                };
        };

        fragment@6 {
                target = <&trip5>;
                __overlay__ {
                        temperature = <71000>;
                        hysteresis = <3000>;
                };
        };

        fragment@7 {
                target = <&trip6>;
                __overlay__ {
                        temperature = <75000>;
                        hysteresis = <3000>;
                };
        };

        fragment@8 {
                target = <&pcritical>;
                __overlay__ {
                        temperature = <80000>;
                        hysteresis = <3000>;
                };
        };
};
```

But this is a larger change, debatable. The board never exceeds 68 degrees. In my opinion trip points that start at 45 degrees make little sense. Again, the reasoning is in #532.