### PR TITLE
rk3576: panfrost GPU DT overlay + SoC-specific compatible

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
@@ -137,6 +137,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rockchip-rk3588-dmc-oc-3500mhz.dtbo \
 	rockchip-rk3588-opp-oc-24ghz.dtbo \
 	rockchip-rk3588-panthor-gpu.dtbo \
+	rockchip-rk3576-panfrost-gpu.dtbo \
 	rk3528-rock-2-enable-pcie.dtbo \
 	rk3566-roc-pc-sata2.dtbo \
 	rk3576-can1-m1.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3576-panfrost-gpu.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/rockchip-rk3576-panfrost-gpu.dts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * DT overlay for reComputer RK3576 (Mali-G52): switch the GPU from the vendor
+ * kbase KMD (CONFIG_MALI_BIFROST) to the mainline panfrost KMD
+ * (CONFIG_DRM_PANTFROST), mirroring rockchip-rk3588-panthor-gpu.
+ *
+ * fragment@0 disables the vendor gpu node; fragment@1 instantiates a parallel
+ * node for panfrost with a SoC-specific compatible ("rockchip,rk3576-mali")
+ * that only panfrost matches (kbase matches "arm,mali-bifrost", so reusing it
+ * on both nodes would make the two KMDs race for the same node when both are
+ * built as modules).
+ *
+ * With both KMDs in the kernel exactly one driver binds, picked by this
+ * overlay at boot. Remove the overlay from armbianEnv.txt to switch back to
+ * the vendor Mali KMD (install the libmali userspace separately for that
+ * path).
+ */
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/clock/rockchip,rk3576-cru.h>
+#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/power/rk3576-power.h>
+
+/ {
+	fragment@0 {
+		target = <&gpu>;
+		__overlay__ {
+			status = "disabled";
+		};
+	};
+
+	fragment@1 {
+		target-path = "/";
+		__overlay__ {
+			gpu-panfrost@27800000 {
+				compatible = "rockchip,rk3576-mali";
+				reg = <0x0 0x27800000 0x0 0x20000>;
+
+				interrupts = <GIC_SPI 349 IRQ_TYPE_LEVEL_HIGH>,
+					<GIC_SPI 348 IRQ_TYPE_LEVEL_HIGH>,
+					<GIC_SPI 347 IRQ_TYPE_LEVEL_HIGH>;
+				interrupt-names = "gpu", "mmu", "job";
+
+				clocks = <&cru CLK_GPU>;
+				clock-names = "core";
+				assigned-clocks = <&cru CLK_GPU>;
+				assigned-clock-rates = <198000000>;
+				power-domains = <&power RK3576_PD_GPU>;
+				operating-points-v2 = <&gpu_opp_table>;
+				mali-supply = <&vdd_gpu_s0>;
+				#cooling-cells = <2>;
+				dynamic-power-coefficient = <1625>;
+				status = "okay";
+			};
+		};
+	};
+};

--- a/drivers/gpu/drm/panfrost/panfrost_drv.c
+++ b/drivers/gpu/drm/panfrost/panfrost_drv.c
@@ -672,6 +672,7 @@ static const struct of_device_id dt_match[] = {
 	  .data = &amlogic_data, },
 	{ .compatible = "amlogic,meson-g12a-mali",
 	  .data = &amlogic_data, },
+	{ .compatible = "rockchip,rk3576-mali", .data = &default_data, },
 	{ .compatible = "arm,mali-t604", .data = &default_data, },
 	{ .compatible = "arm,mali-t624", .data = &default_data, },
 	{ .compatible = "arm,mali-t628", .data = &default_data, },


### PR DESCRIPTION
## Summary

Add runtime GPU KMD selection for the RK3576 Mali-G52, mirroring the existing `rockchip-rk3588-panthor-gpu` overlay mechanism on RK3588:

- **DT overlay `rockchip-rk3576-panfrost-gpu`**: disables the vendor `gpu` node and instantiates a parallel node for panfrost. With both KMDs in the kernel exactly one driver binds, picked by the overlay at boot (`overlays=rockchip-rk3576-panfrost-gpu` in armbianEnv.txt; dropping it switches back to the vendor Mali KMD).
- **panfrost: add `rockchip,rk3576-mali` compatible**: the new node needs a compatible that only panfrost matches. kbase's of_match table claims the generic `arm,mali-bifrost` as well, so reusing it on both nodes would leave the two KMDs racing for the same node when both are built as modules. SoC-specific compatible, symmetric with `rockchip,rk3588-mali` in this tree's panthor driver.

## Test plan

- [x] Overlay compiles with the kernel dtc; all external refs (`gpu`, `cru`, `power`, `gpu_opp_table`, `vdd_gpu_s0`) resolve via `__fixups__` / `__symbols__`
- [x] Hardware-validated on reComputer RK3576 devkit (vendor 6.1 / vendor u-boot 2017.09): u-boot loads and applies the dtbo (new-node creation via `target-path`), vendor node reports `disabled`, panfrost binds `gpu-panfrost@27800000` (`renderD129 DRIVER=panfrost`), OPP/devfreq energy model up, `mali-supply` resolved
- [ ] Reverse direction (overlay off → vendor kbase binds the generic node) pending a dual-KMD image build (`CONFIG_MALI_BIFROST=m` + `CONFIG_DRM_PANTFROST=m`)