### PR TITLE
WIP: arm64: dts: rockchip: add reComputer Industrial RK3576 (SoM + carrier)

### DIFF
--- a/arch/arm64/boot/dts/rockchip/Makefile
+++ b/arch/arm64/boot/dts/rockchip/Makefile
@@ -462,6 +462,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588s-tablet-v11.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-luckfox-core3566.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3566-roc-pc.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3576-recomputer-rk3576-devkit.dtb
+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3576-recomputer-industrial.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3588-recomputer-rk3588-devkit.dtb
 subdir-y := $(dts-dirs) overlay
 

--- a/arch/arm64/boot/dts/rockchip/rk3576-recomputer-industrial.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3576-recomputer-industrial.dts
@@ -1,0 +1,556 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Seeed Studio reComputer Industrial RK3576
+ *
+ * Carrier board on top of the reComputer RK3576 SoM:
+ *   - USB3.1 hub USB5744: 2x USB3 Type-A, CH344 UART board (2x RS485 + RS232),
+ *     Mini PCIe 4G modem
+ *   - GMAC1 PHY Maxio MAE0621A (RJ45 with PoE 802.3af)
+ *   - USB3 OTG0 Type-C with 4-lane DP alt-mode, AW35615/FUSB302 CC controller
+ *   - CAN1 with isolated transceiver TPT71044 (terminal resistor switch)
+ *   - Mini PCIe with LoRa SX1261 (SPI3_M0) and 4G (USB via hub)
+ *   - M.2 Key-M NVMe (PCIE0)
+ *   - HDMI Type-A, ES8311 codec (I2C0_M1 + SAI1_M0)
+ *   - CH343P debug console (UART0_M0), SGM706B watchdog, buzzer,
+ *     RGB user LED, isolated DI/DO, boot-mode DIP switch (SARADC0)
+ *
+ * No fan, no TF card slot on this board.
+ *
+ * Copyright (c) 2026 Seeed Studio
+ */
+
+/dts-v1/;
+
+#include <dt-bindings/usb/pd.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/input/rk-input.h>
+#include <dt-bindings/display/drm_mipi_dsi.h>
+#include <dt-bindings/display/rockchip_vop.h>
+#include <dt-bindings/sensor-dev.h>
+#include "rk3576-recomputer-som.dtsi"
+#include "rk3576-recomputer-som-emmc.dtsi"
+
+/ {
+	model = "Seeed Studio reComputer Industrial RK3576";
+	compatible = "seeed,recomputer-industrial-rk3576", "rockchip,rk3576";
+
+	/delete-node/ chosen;
+
+	chosen: chosen {
+		stdout-path = "serial0:1500000n8";
+	};
+
+	/* Type-C0 VBUS 5V, TYPEC5V_PWREN_H = GPIO4_C6 */
+	vcc5v0_otg: vcc5v0-otg {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc5v0_otg";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		enable-active-high;
+		gpio = <&gpio4 RK_PC6 GPIO_ACTIVE_HIGH>;
+		vin-supply = <&vcc_sys>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&typec5v_pwren>;
+	};
+
+	es8311_sound: es8311-sound {
+		status = "okay";
+		compatible = "rockchip,multicodecs-card";
+		rockchip,card-name = "rockchip-es8311";
+		keyup-threshold-microvolt = <1800000>;
+		/* HP_DET_L = GPIO4_A6 */
+		hp-det-gpio = <&gpio4 RK_PA6 GPIO_ACTIVE_HIGH>;
+		/* HP_CTL_H = GPIO4_A4 */
+		hp-con-gpio = <&gpio4 RK_PA4 GPIO_ACTIVE_HIGH>;
+		rockchip,pre-power-on-delay-ms = <30>;
+		rockchip,post-power-down-delay-ms = <40>;
+		rockchip,format = "i2s";
+		rockchip,mclk-fs = <256>;
+		rockchip,cpu = <&sai1>;
+		rockchip,codec = <&es8311>;
+		rockchip,audio-routing =
+			"Headphone", "DIFFERENTIAL OUT",
+			/* No on-board mic: the headset jack MIC contact is the only
+			 * capture source. Route both jack widgets to AMIC (same as
+			 * the devkit dts) so a 4-pole headset mic can record.
+			 */
+			"AMIC", "Main Mic",
+			"AMIC", "Headset Mic";
+		pinctrl-names = "default";
+		pinctrl-0 = <&hp_det &hp_con>;
+	};
+
+	dp0_sound: dp0-sound {
+		compatible = "rockchip,hdmi";
+		rockchip,mclk-fs = <512>;
+		rockchip,card-name = "rockchip-dp0";
+		rockchip,cpu = <&spdif_tx3>;
+		rockchip,codec = <&dp0 1>;
+		rockchip,jack-det;
+	};
+
+	/* USR_LED_R/G/B = GPIO2_A0/A1/A2, STATE_LED = GPIO0_C5 (J12 header) */
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		usr-led-r {
+			gpios = <&gpio2 RK_PA0 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "none";
+		};
+
+		usr-led-g {
+			gpios = <&gpio2 RK_PA1 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "none";
+		};
+
+		usr-led-b {
+			gpios = <&gpio2 RK_PA2 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "none";
+		};
+
+		state-led {
+			gpios = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+		};
+	};
+
+	/*
+	 * Buzzer (passive, driven by 2N7002). PWM square wave on
+	 * pwm2_ch7_m2 (GPIO2_D7); input EV_SND, drive with
+	 * `beep -e /dev/input/eventX -f 2730 -l 200`.
+	 */
+	buzzer: pwm-beeper {
+		status = "okay";
+		compatible = "pwm-beeper";
+		pwms = <&pwm2_8ch_7 0 5000 0>;
+	};
+
+	/*
+	 * External watchdog SGM706B. RST_WDI = GPIO0_C4 must be
+	 * toggled within 1.6s or the board resets (RESET_L_1V8).
+	 */
+	gpio_watchdog: gpio-watchdog {
+		compatible = "linux,wdt-gpio";
+		gpios = <&gpio0 RK_PC4 GPIO_ACTIVE_HIGH>;
+		/* required by gpio-wdt or probe fails with -EINVAL */
+		hw_algo = "toggle";
+		hw_margin_ms = <1300>;
+		always-running;
+		status = "okay";
+	};
+
+	/*
+	 * Boot-mode DIP switch (nRPIBOOT): SARADC channel 0 divider,
+	 * selects maskrom/recovery boot (handled by the boot ROM).
+	 * Exposed as a key for userspace notification.
+	 */
+	boot-keys {
+		compatible = "adc-keys";
+		io-channels = <&saradc 0>;
+		io-channel-names = "buttons";
+		keyup-threshold-microvolt = <1800000>;
+		status = "okay";
+
+		boot-mode-switch {
+			linux,code = <KEY_SETUP>;
+			label = "boot mode";
+			/* 5V through 100R + 100R divider, clamped to 1V8 domain.
+			 * Measured 2026-08-21: normal position ~1614mV, maskrom
+			 * position ~15mV; threshold set at the midpoint.
+			 */
+			press-threshold-microvolt = <800000>;
+		};
+	};
+};
+
+/* Debug console: CH343P USB-UART on Type-C1 */
+&uart0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart0m0_xfer>;
+};
+
+/*
+ * rk3576-linux.dtsi enables a fiq-debugger on UART0 (serial-id 0), which
+ * requires the uart0 node to stay disabled ("uart0 is enabled, please
+ * disable it" -> probe -EEXIST/-EINVAL). This board uses the plain 16550
+ * ttyS0 console instead (SERIALCON=ttyS0; the shared bootscript's
+ * console=ttyFIQ0 is overridden via extraargs), so turn the debugger off.
+ */
+&fiq_debugger {
+	status = "disabled";
+};
+
+/* ES8311 I2S, SAI1_M0 */
+&sai1 {
+	status = "okay";
+	rockchip,sai-rx-route = <0 1 2 3>;
+	rockchip,sai-tx-route = <0 1 2 3>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&sai1m0_lrck
+		     &sai1m0_sclk
+		     &sai1m0_sdi0
+		     &sai1m0_sdo0>;
+};
+
+/*
+ * I2C0_M1 (GPIO0_C1/C2): carrier codec + Type-C CC controller.
+ */
+&i2c0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c0m1_xfer>;
+
+	es8311: es8311@18 {
+		status = "okay";
+		compatible = "everest,es8311";
+		reg = <0x18>;
+		#sound-dai-cells = <0>;
+		adc-pga-gain = <6>;     /* 18dB */
+		adc-volume = <0xbf>;    /* 0dB */
+		dac-volume = <0xbf>;    /* 0dB */
+		aec-mode = "adc left, adc right";
+		clocks = <&mclkout_sai1>;
+		clock-names = "mclk";
+		assigned-clocks = <&mclkout_sai1>;
+		assigned-clock-rates = <12288000>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&sai1m0_mclk>;
+	};
+
+	/* TypeC0 CC controller: AW35615 (default) / HUSB311 (option), FUSB302 compatible */
+	usbc0: fusb302@22 {
+		compatible = "fcs,fusb302";
+		reg = <0x22>;
+		interrupt-parent = <&gpio0>;
+		interrupts = <RK_PB4 IRQ_TYPE_LEVEL_LOW>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&typec_int>;
+		vbus-supply = <&vcc5v0_otg>;
+		status = "okay";
+
+		ports {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			port@0 {
+				reg = <0>;
+				usbc0_role_sw: endpoint@0 {
+					remote-endpoint = <&usb_drd0_role_switch>;
+				};
+			};
+		};
+
+		usb_con: connector {
+			compatible = "usb-c-connector";
+			label = "USB-C";
+			data-role = "dual";
+			power-role = "dual";
+			try-power-role = "sink";
+			op-sink-microwatt = <1000000>;
+			sink-pdos =
+				<PDO_FIXED(5000, 1000, PDO_FIXED_USB_COMM)>;
+			source-pdos =
+				<PDO_FIXED(5000, 3000, PDO_FIXED_USB_COMM)>;
+
+			altmodes {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				altmode@0 {
+					reg = <0>;
+					svid = <0xff01>;
+					vdo = <0xffffffff>;
+				};
+			};
+
+			ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				port@0 {
+					reg = <0>;
+					usbc0_orien_sw: endpoint {
+						remote-endpoint = <&usbdp_phy_orientation_switch>;
+					};
+				};
+
+				port@1 {
+					reg = <1>;
+					dp_altmode_mux: endpoint {
+						remote-endpoint = <&usbdp_phy_dp_altmode_mux>;
+					};
+				};
+			};
+		};
+	};
+};
+
+/* I2C3_M1 (GPIO0_C6/C7): Mini PCIe SIM switch (SGM7222) + module ID */
+&i2c3 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c3m1_xfer>;
+};
+
+/*
+ * SPI3_M0 (GPIO3_A0-A3): LoRa SX1261 on Mini PCIe.
+ * No in-tree SX126x SPI driver; expose as spidev for now.
+ */
+&spi3 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi3m0_pins &spi3m0_csn0>;
+
+	spidev@0 {
+		compatible = "spidev";
+		reg = <0>;
+		spi-max-frequency = <5000000>;
+		status = "okay";
+	};
+
+	/* sx1261: lora@0 { compatible = "semtech,sx1261"; ... }; */
+};
+
+/* Buzzer PWM: pwm2_ch7_m2 on GPIO2_D7 (see pwm-beeper above) */
+&pwm2_8ch_7 {
+	status = "okay";
+	pinctrl-names = "active";
+	pinctrl-0 = <&pwm2m2_ch7>;
+};
+
+/*
+ * GMAC1: Maxio MAE0621A on carrier, RGMII M0.
+ * PHY address 0x0, reset GPIO2_B4.
+ * No Maxio PHY driver in the vendor kernel and the strap leaves the
+ * PHY's internal RGMII delays off, so phy-mode is "rgmii" and both
+ * delays come from the MAC side. Calibrated on the board: tx 0x1a /
+ * rx 0x1a gives clean RX (0 crc errors) and 0% ping loss; rx 0x3f and
+ * PHY-side delay modes (rgmii-rxid / rgmii-id) fail RX with CRC errors.
+ */
+&gmac1 {
+	phy-mode = "rgmii";
+	clock_in_out = "output";
+
+	snps,reset-gpio = <&gpio2 RK_PB4 GPIO_ACTIVE_LOW>;
+	snps,reset-active-low;
+	snps,reset-delays-us = <0 20000 100000>;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth1m0_miim
+		     &eth1m0_tx_bus2
+		     &eth1m0_rx_bus2
+		     &eth1m0_rgmii_clk
+		     &eth1m0_rgmii_bus>;
+
+	tx_delay = <0x1a>;
+	rx_delay = <0x1a>;
+
+	phy-handle = <&rgmii_phy1>;
+	status = "okay";
+};
+
+&mdio1 {
+	rgmii_phy1: phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0x0>;
+		/*
+		 * No dedicated binding: bound by the generic C22 driver.
+		 * RJ45 LEDs fall back to the PHY strap default (amber
+		 * steady on) until a dedicated MAE0621A driver lands.
+		 */
+	};
+};
+
+/* CAN1: TPT71044 isolated transceiver, GPIO4_B4/B5 (M2) */
+&can1 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&can1m2_pins>;
+};
+
+/* PCIe0: M.2 Key-M NVMe, PERST GPIO2_B1 */
+&pcie0 {
+	reset-gpios = <&gpio2 RK_PB1 GPIO_ACTIVE_HIGH>;
+	rockchip,skip-scan-in-resume;
+	status = "okay";
+};
+
+&combphy0_ps {
+	status = "okay";
+};
+
+/* USB3 OTG0 with 4-lane DP alt-mode on Type-C0 */
+&usbdp_phy {
+	orientation-switch;
+	svid = <0xff01>;
+	rockchip,dp-lane-mux = <0 1 2 3>;
+	sbu1-dc-gpios = <&gpio4 RK_PC4 GPIO_ACTIVE_HIGH>;
+	sbu2-dc-gpios = <&gpio4 RK_PC5 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+
+	port {
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		usbdp_phy_orientation_switch: endpoint@0 {
+			reg = <0>;
+			remote-endpoint = <&usbc0_orien_sw>;
+		};
+
+
+		usbdp_phy_dp_altmode_mux: endpoint@1 {
+			reg = <1>;
+			remote-endpoint = <&dp_altmode_mux>;
+		};
+	};
+};
+
+&usbdp_phy_dp {
+	status = "okay";
+};
+
+&usbdp_phy_u3 {
+	status = "okay";
+};
+
+&u2phy0 {
+	status = "okay";
+};
+
+&u2phy0_otg {
+	rockchip,typec-vbus-det;
+	status = "okay";
+};
+
+&usb_drd0_dwc3 {
+	dr_mode = "otg";
+	usb-role-switch;
+	status = "okay";
+	snps,parkmode-disable-hs-quirk;
+	snps,parkmode-disable-ss-quirk;
+	snps,dis_u3_susphy_quirk;
+	snps,dis_u2_susphy_quirk;
+	port {
+		usb_drd0_role_switch: endpoint {
+			remote-endpoint = <&usbc0_role_sw>;
+		};
+	};
+};
+
+/* DP alt-mode output */
+&dp {
+	status = "okay";
+};
+
+&dp0 {
+	status = "okay";
+};
+
+&dp0_in_vp0 {
+	status = "disabled";
+};
+
+&dp0_in_vp1 {
+	status = "okay";
+};
+
+&dp0_in_vp2 {
+	status = "disabled";
+};
+
+&vp1 {
+	status = "okay";
+};
+
+&route_dp0 {
+	status = "okay";
+	connect = <&vp1_out_dp0>;
+};
+
+&dp0_sound {
+	status = "okay";
+};
+
+&spdif_tx3 {
+	status = "okay";
+};
+
+&gpio0 {
+	/* USB5744 hub reset, UPR (GPIO0_C3) */
+	usb_hub_reset_hog: usb-hub-reset-hog {
+		gpio-hog;
+		gpios = <RK_PC3 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "usb_hub_reset";
+	};
+
+	/* CH344 (USB to 4x UART, RS485x2/RS232) reset, GPIO0_B5 */
+	ch344_reset_hog: ch344-reset-hog {
+		gpio-hog;
+		gpios = <RK_PB5 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "ch344_reset";
+	};
+};
+
+&gpio2 {
+	/*
+	 * CAN 120-ohm termination switch (GPIO2_A6):
+	 * low = terminator disconnected (default)
+	 */
+	can_120r_hog: can-120r-hog {
+		gpio-hog;
+		gpios = <RK_PA6 GPIO_ACTIVE_HIGH>;
+		output-low;
+		line-name = "can_120r_en";
+	};
+
+	/* Isolated 5V DCDC (IB0505S) enable, GPIO2_A4 */
+	iso_5v_hog: iso-5v-hog {
+		gpio-hog;
+		gpios = <RK_PA4 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "5v_iso_en";
+	};
+};
+
+&pinctrl {
+
+	headphone {
+		hp_det: hp-det {
+			rockchip,pins = <4 RK_PA6 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+		hp_con: hp-con {
+			rockchip,pins = <4 RK_PA4 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+	};
+
+	usb {
+		/* AW35615 INT */
+		typec_int: typec-int {
+			rockchip,pins = <0 RK_PB4 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+		typec5v_pwren: typec5v-pwren {
+			rockchip,pins = <4 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+};
+
+&gpio2 {
+	gpio-line-names =
+		/* GPIO2_A0-A7 */
+		"USR_LED_R", "USR_LED_G", "USR_LED_B", "ISO_DOUT1",
+		"5V_ISO_EN", "ISO_DIN1", "CAN_120R_EN", "I2C_SWITCH_CTL",
+		/* GPIO2_B0-B7 */
+		"HDMI_TX_ON_H", "PCIE0_PERSTn", "", "GMAC0_RSTn",
+		"GMAC1_RSTn", "PCIE_1PPS", "SX1261_RST", "M2B_PCIE_Reset",
+		/* GPIO2_C0-C7 */
+		"GMAC1_RXD2", "GMAC1_RXD3", "GMAC1_RXCLK", "GMAC1_TXD2",
+		"GMAC1_TXD3", "GMAC1_TXCLK", "GMAC1_TXD0", "GMAC1_TXD1",
+		/* GPIO2_D0-D7 */
+		"GMAC1_TXCTL", "GMAC1_RXD0", "GMAC1_RXD1", "GMAC1_RXCTL",
+		"GMAC1_MDC", "GMAC1_MDIO", "SX1261_BUSY", "BUZZER_EN";
+};

--- a/arch/arm64/boot/dts/rockchip/rk3576-recomputer-industrial.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3576-recomputer-industrial.dts
@@ -494,6 +494,17 @@
 		output-high;
 		line-name = "ch344_reset";
 	};
+
+	/* EEPROM FT24C32 nWP (GPIO0_D1): low = writable, high = write-protect.
+	 * The at24 driver in this kernel does not toggle a wp-gpios line, so
+	 * hog GPIO0_D1 low to allow page writes (read/write/restore test).
+	 */
+	eeprom_wp_hog: eeprom-wp-hog {
+		gpio-hog;
+		gpios = <RK_PD1 GPIO_ACTIVE_HIGH>;
+		output-low;
+		line-name = "eeprom_wp";
+	};
 };
 
 &gpio2 {

--- a/arch/arm64/boot/dts/rockchip/rk3576-recomputer-industrial.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3576-recomputer-industrial.dts
@@ -114,6 +114,26 @@
 			gpios = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
 			linux,default-trigger = "heartbeat";
 		};
+
+		/* CAN 120R termination switch (GPIO2_A6): brightness
+		 * 1 = terminator connected, 0 = disconnected (default).
+		 * Userspace: /sys/class/leds/can-120r-en/brightness
+		 */
+		can-120r-en {
+			gpios = <&gpio2 RK_PA6 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "none";
+			default-state = "off";
+		};
+
+		/* Isolated 5V DCDC (IB0505S) enable (GPIO2_A4): brightness
+		 * 1 = rail on (default), 0 = rail off.
+		 * Userspace: /sys/class/leds/iso-5v-en/brightness
+		 */
+		iso-5v-en {
+			gpios = <&gpio2 RK_PA4 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "none";
+			default-state = "on";
+		};
 	};
 
 	/*
@@ -479,6 +499,16 @@
 };
 
 &gpio0 {
+	gpio-line-names =
+		/* GPIO0_A0-A7 */
+		"", "", "", "", "", "", "", "",
+		/* GPIO0_B0-B7 */
+		"", "", "", "", "TYPEC_INT", "CH344_RESET", "", "",
+		/* GPIO0_C0-C7 */
+		"", "", "", "USB_HUB_RESET", "EXT_WDT_WDI", "STATE_LED", "", "",
+		/* GPIO0_D0-D7 */
+		"", "EEPROM_WP", "", "", "", "", "", "";
+
 	/* USB5744 hub reset, UPR (GPIO0_C3) */
 	usb_hub_reset_hog: usb-hub-reset-hog {
 		gpio-hog;
@@ -493,38 +523,6 @@
 		gpios = <RK_PB5 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "ch344_reset";
-	};
-
-	/* EEPROM FT24C32 nWP (GPIO0_D1): low = writable, high = write-protect.
-	 * The at24 driver in this kernel does not toggle a wp-gpios line, so
-	 * hog GPIO0_D1 low to allow page writes (read/write/restore test).
-	 */
-	eeprom_wp_hog: eeprom-wp-hog {
-		gpio-hog;
-		gpios = <RK_PD1 GPIO_ACTIVE_HIGH>;
-		output-low;
-		line-name = "eeprom_wp";
-	};
-};
-
-&gpio2 {
-	/*
-	 * CAN 120-ohm termination switch (GPIO2_A6):
-	 * low = terminator disconnected (default)
-	 */
-	can_120r_hog: can-120r-hog {
-		gpio-hog;
-		gpios = <RK_PA6 GPIO_ACTIVE_HIGH>;
-		output-low;
-		line-name = "can_120r_en";
-	};
-
-	/* Isolated 5V DCDC (IB0505S) enable, GPIO2_A4 */
-	iso_5v_hog: iso-5v-hog {
-		gpio-hog;
-		gpios = <RK_PA4 GPIO_ACTIVE_HIGH>;
-		output-high;
-		line-name = "5v_iso_en";
 	};
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3576-recomputer-som-emmc.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3576-recomputer-som-emmc.dtsi
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * reComputer RK3576 SoM storage variant: eMMC (default SKU)
+ *
+ * U36 eMMC (VFBGA-153, 32/64/128GB) on shared FSPI0 pads,
+ * 8-bit bus with HS400 enhanced strobe. R591-R596 (SPI NOR
+ * series resistors) are DNP on this variant.
+ *
+ * Copyright (c) 2026 Seeed Studio
+ */
+
+/* eMMC on module (32/64/128GB, 8-bit HS400) */
+&sdhci {
+	bus-width = <8>;
+	no-sdio;
+	no-sd;
+	non-removable;
+	max-frequency = <200000000>;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
+	full-pwr-cycle-in-suspend;
+	status = "okay";
+};
+
+/* keep the SFC controller out of the way of the eMMC pads */
+&sfc0 {
+	status = "disabled";
+};

--- a/arch/arm64/boot/dts/rockchip/rk3576-recomputer-som-flash.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3576-recomputer-som-flash.dtsi
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * reComputer RK3576 SoM storage variant: SPI NOR flash
+ *
+ * U40 SPI NOR (SOP-8, quad, 3V3) on shared FSPI0 pads, wired
+ * through R591-R596 (stuffed on this variant; eMMC U36 not mounted):
+ *   CS  = FSPI0_CSN0, CLK = FSPI0_CLK,
+ *   D0-D3 = FSPI0_D0..D3 (IO0 SI / IO1 SO / IO2 WP / IO3 HOLD)
+ * Flash part is selectable at stuffing time; capacity is probed
+ * at runtime, no fixed partition map (add one to match the SKU).
+ *
+ * Copyright (c) 2026 Seeed Studio
+ */
+
+/* eMMC pads are reused by SFC0 on this variant */
+&sdhci {
+	status = "disabled";
+};
+
+&sfc0 {
+	status = "okay";
+	max-freq = <50000000>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&fspi0_pins>;
+
+	spi_flash: spi-flash@0 {
+		#address-cells = <1>;
+		#size-cells = <0>;
+		compatible = "jedec,spi-nor";
+		reg = <0x0>;
+		spi-max-frequency = <50000000>;
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <4>;
+		status = "okay";
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/rk3576-recomputer-som.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3576-recomputer-som.dtsi
@@ -1,0 +1,483 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * reComputer RK3576 SoM (SOM board, 200-pin BTB carrier)
+ *
+ * On-module devices:
+ *   - RK3576 + RK806S PMIC + LPDDR5 + eMMC
+ *   - WiFi/BT combo module (FCS960KAAMD, SDIO + UART)
+ *   - GMAC0 PHY RTL8211F-CG (RGMII, MDI routed to carrier)
+ *   - EEPROM FT24C32A + RTC PCF85063 (shared I2C2_M0)
+ *   - HDMI TX (enable/HPD/DDC generated on module)
+ *   - USB3 OTG0 (DP alt-mode capable) / USB2 OTG0 / USB2+USB3 OTG1
+ *
+ * Carrier-board devices belong to the board dts including this file.
+ *
+ * Copyright (c) 2026 Seeed Studio
+ */
+
+#include <dt-bindings/usb/pd.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/input/rk-input.h>
+#include <dt-bindings/display/drm_mipi_dsi.h>
+#include <dt-bindings/display/rockchip_vop.h>
+#include <dt-bindings/sensor-dev.h>
+#include "rk3576.dtsi"
+#include "rk3576-linux.dtsi"
+#include "rk3576-rk806.dtsi"
+
+/ {
+	vcc_sys: vcc5v0-sys {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_sys";
+		regulator-always-on;
+		regulator-boot-on;
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+	};
+
+	vcc_2v0_pldo_s3: vcc-2v0-pldo-s3 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_2v0_pldo_s3";
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-min-microvolt = <2000000>;
+		regulator-max-microvolt = <2000000>;
+		vin-supply = <&vcc_sys>;
+	};
+
+	vcc_1v1_nldo_s3: vcc-1v1-nldo-s3 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_1v1_nldo_s3";
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-min-microvolt = <1100000>;
+		regulator-max-microvolt = <1100000>;
+		vin-supply = <&vcc_sys>;
+	};
+
+	vcc_1v8_s0: vcc-1v8-s0 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_1v8_s0";
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		vin-supply = <&vcc_1v8_s3>;
+	};
+
+	vcc_3v3_s0: vcc-3v3-s0 {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc_3v3_s0";
+		regulator-boot-on;
+		regulator-always-on;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		vin-supply = <&vcc_3v3_s3>;
+	};
+
+	sdio_pwrseq: sdio-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		pinctrl-names = "default";
+		pinctrl-0 = <&wifi_poweren_gpio>;
+
+		/* WIFI_REG_ON_H, active low reset (PDN) */
+		post-power-on-delay-ms = <200>;
+		reset-gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
+	};
+
+	wireless_wlan: wireless-wlan {
+		compatible = "wlan-platdata";
+		wifi_chip_type = "fcs960k";
+		clocks = <&pcf85063>;
+		clock-names = "ext_clock";
+		pinctrl-names = "default";
+		pinctrl-0 = <&wifi_host_wake_irq>;
+		WIFI,host_wake_irq = <&gpio0 RK_PB0 GPIO_ACTIVE_HIGH>;
+	};
+
+	wireless_bluetooth: wireless-bluetooth {
+		compatible = "bluetooth-platdata";
+		uart_rts_gpios = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
+		pinctrl-names = "default", "rts_gpio";
+		pinctrl-0 = <&uart4m1_rtsn>;
+		pinctrl-1 = <&uart4_gpios>;
+		BT,reset_gpio    = <&gpio1 RK_PC7 GPIO_ACTIVE_HIGH>;
+		BT,wake_gpio     = <&gpio1 RK_PD4 GPIO_ACTIVE_HIGH>;
+		BT,wake_host_irq = <&gpio0 RK_PB1 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+	};
+
+	hdmi_sound: hdmi-sound {
+		compatible = "rockchip,hdmi";
+		rockchip,mclk-fs = <128>;
+		rockchip,card-name = "rockchip-hdmi0";
+		rockchip,cpu = <&sai6>;
+		rockchip,codec = <&hdmi>;
+		rockchip,jack-det;
+	};
+};
+
+/*
+ * Boot storage on module comes in two mutually exclusive flavors
+ * (shared FSPI0/eMMC pads, selected by R591-R596 stuffing):
+ *   - eMMC variant (default): see rk3576-recomputer-som-emmc.dtsi
+ *   - SPI NOR variant:        see rk3576-recomputer-som-flash.dtsi
+ * The board dts includes exactly one of them.
+ */
+
+/* WiFi (FCS960KAAMD) */
+&sdio {
+	max-frequency = <100000000>;
+	no-sd;
+	no-mmc;
+	bus-width = <4>;
+	disable-wp;
+	cap-sd-highspeed;
+	cap-sdio-irq;
+	keep-power-in-suspend;
+	mmc-pwrseq = <&sdio_pwrseq>;
+	non-removable;
+	pinctrl-names = "default";
+	pinctrl-0 = <&sdmmc1m0_bus4 &sdmmc1m0_clk &sdmmc1m0_cmd>;
+	sd-uhs-sdr50;
+	sd-uhs-sdr104;
+	status = "okay";
+};
+
+/* BT */
+&uart4 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart4m1_xfer &uart4m1_ctsn>;
+};
+
+&cpu_l0 {
+	cpu-supply = <&vdd_cpu_lit_s0>;
+};
+
+&cpu_b0 {
+	cpu-supply = <&vdd_cpu_big_s0>;
+};
+
+&crypto {
+	status = "okay";
+};
+
+&gpu {
+	mali-supply = <&vdd_gpu_s0>;
+	status = "okay";
+};
+
+&iep {
+	status = "okay";
+};
+
+&iep_mmu {
+	status = "okay";
+};
+
+&jpegd {
+	status = "okay";
+};
+
+&jpege {
+	status = "okay";
+};
+
+&jpeg_mmu {
+	status = "okay";
+};
+
+&mpp_srv {
+	status = "okay";
+};
+
+&rga2_core0 {
+	status = "okay";
+};
+
+&rga2_core0_mmu {
+	status = "okay";
+};
+
+&rga2_core1 {
+	status = "okay";
+};
+
+&rga2_core1_mmu {
+	status = "okay";
+};
+
+&rknpu {
+	rknpu-supply = <&vdd_npu_s0>;
+	status = "okay";
+};
+
+&rknpu_mmu {
+	status = "okay";
+};
+
+&rkvenc_ccu {
+	status = "okay";
+};
+
+&rkvenc0 {
+	status = "okay";
+};
+
+&rkvenc0_mmu {
+	status = "okay";
+};
+
+&rkvenc1 {
+	status = "okay";
+};
+
+&rkvenc1_mmu {
+	status = "okay";
+};
+
+&rkvdec {
+	status = "okay";
+};
+
+&rkvdec_mmu {
+	status = "okay";
+};
+
+&rockchip_suspend {
+	status = "okay";
+	rockchip,sleep-debug-en = <1>;
+
+	rockchip,sleep-io-ret-config = <
+		(0
+		| RKPM_VCCIO3_RET_EN
+		)
+	>;
+
+	rockchip,regulator-on-before-mem = <&vdd_npu_s0>;
+};
+
+&vdd_logic_s0 {
+	regulator-state-mem {
+		regulator-on-in-suspend;
+	};
+};
+
+&vcca_1v8_s0 {
+	regulator-state-mem {
+		regulator-on-in-suspend;
+	};
+};
+
+&saradc {
+	status = "okay";
+	vref-supply = <&vcca_1v8_s0>;
+};
+
+&tsadc {
+	status = "okay";
+};
+
+&vdpp {
+	status = "okay";
+};
+
+&vop {
+	status = "okay";
+	vop-supply = <&vdd_logic_s0>;
+};
+
+&vop_mmu {
+	status = "okay";
+};
+
+&vp1 {
+	assigned-clocks = <&cru DCLK_VP1_SRC>;
+	assigned-clock-parents = <&cru PLL_VPLL>;
+};
+
+&vp2 {
+	assigned-clocks = <&cru DCLK_VP2_SRC>;
+	assigned-clock-parents = <&cru PLL_VPLL>;
+};
+
+&display_subsystem {
+	clocks = <&hdptxphy_hdmi>;
+	clock-names = "hdmi0_phy_pll";
+};
+
+/* HDMI TX on module, Type-A connector on carrier */
+&hdmi {
+	status = "okay";
+	cec-enable;
+	/* HDMI_TX_ON_H */
+	enable-gpios = <&gpio2 RK_PB0 GPIO_ACTIVE_HIGH>;
+	ddc-i2c-scl-high-time-ns = <4812>;
+	ddc-i2c-scl-low-time-ns = <5000>;
+};
+
+&hdmi_in_vp0 {
+	status = "okay";
+};
+
+&hdmi_in_vp1 {
+	status = "disabled";
+};
+
+&hdmi_in_vp2 {
+	status = "disabled";
+};
+
+&hdmi_in_vopl {
+	status = "disabled";
+};
+
+&hdptxphy_hdmi {
+	status = "okay";
+};
+
+&route_hdmi {
+	status = "okay";
+	connect = <&vp0_out_hdmi>;
+};
+
+&hdmi_sound {
+	status = "okay";
+};
+
+&vp0 {
+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0)>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART0>;
+	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER0>;
+};
+
+&vp1 {
+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER1 | 1 << ROCKCHIP_VOP2_ESMART1)>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART1>;
+	cursor-win-id = <ROCKCHIP_VOP2_CLUSTER1>;
+};
+
+&vp2 {
+	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_ESMART2 | 1 << ROCKCHIP_VOP2_ESMART3)>;
+	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART2>;
+	cursor-win-id = <ROCKCHIP_VOP2_ESMART3>;
+};
+
+/*
+ * GMAC0: RTL8211F-CG on module, RGMII M0.
+ * PHY address 0x1 (PHYAD[2:0] = 001), reset GPIO2_B3.
+ * 25 MHz crystal on module (REFCLKO25M output not routed, R210 DNP).
+ */
+&gmac0 {
+	phy-mode = "rgmii-rxid";
+	clock_in_out = "output";
+
+	snps,reset-gpio = <&gpio2 RK_PB3 GPIO_ACTIVE_LOW>;
+	snps,reset-active-low;
+	/* Reset time is 20ms, 100ms for rtl8211f */
+	snps,reset-delays-us = <0 20000 100000>;
+
+	pinctrl-names = "default";
+	pinctrl-0 = <&eth0m0_miim
+		     &eth0m0_tx_bus2
+		     &eth0m0_rx_bus2
+		     &eth0m0_rgmii_clk
+		     &eth0m0_rgmii_bus>;
+
+	tx_delay = <0x20>;
+	/* rx_delay = <0x3f>; */
+
+	phy-handle = <&rgmii_phy0>;
+	status = "okay";
+};
+
+&mdio0 {
+	rgmii_phy0: phy@1 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		realtek,clkout-disable;
+		reg = <0x1>;
+	};
+};
+
+/* HDMI audio I2S */
+&sai6 {
+	status = "okay";
+};
+
+/* USB2/USB3 OTG1: host, carrier may attach a hub (USB5744) */
+&u2phy1 {
+	status = "okay";
+};
+
+&u2phy1_otg {
+	phy-supply = <&vcc_3v3_s0>;
+	status = "okay";
+};
+
+&usb_drd1_dwc3 {
+	dr_mode = "host";
+	status = "okay";
+};
+
+&combphy1_psu {
+	status = "okay";
+};
+
+/*
+ * I2C2_M0: on-module EEPROM (FT24C32A @0x50) + RTC (PCF85063 @0x51).
+ * RTC backup: VBAT_RTC from carrier super-capacitor.
+ */
+&i2c2 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&i2c2m0_xfer>;
+
+	eeprom: ft24c32@50 {
+		status = "okay";
+		compatible = "atmel,24c32";
+		reg = <0x50>;
+		pagesize = <32>;
+	};
+
+	pcf85063: rtc@51 {
+		compatible = "nxp,pcf85063a";
+		reg = <0x51>;
+		wakeup-source;
+		status = "okay";
+		interrupt-parent = <&gpio0>;
+		interrupts = <RK_PA5 IRQ_TYPE_EDGE_FALLING>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&rtc_int>;
+		#clock-cells = <0>;
+		clock-frequency = <32768>;
+		clock-output-names = "xin32k";
+	};
+};
+
+&pinctrl {
+
+	wifi {
+		wifi_host_wake_irq: wifi-host-wake-irq {
+			rockchip,pins = <0 RK_PB0 RK_FUNC_GPIO &pcfg_pull_down>;
+		};
+
+		wifi_poweren_gpio: wifi-poweren-gpio {
+			rockchip,pins = <1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
+	wireless-bluetooth {
+		uart4_gpios: uart4-gpios {
+			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
+	rtc_pinctrl {
+		rtc_int: rtc-int {
+			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+	};
+};

--- a/arch/arm64/boot/dts/rockchip/rk3576-recomputer-som.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3576-recomputer-som.dtsi
@@ -440,6 +440,14 @@
 		compatible = "atmel,24c32";
 		reg = <0x50>;
 		pagesize = <32>;
+		/*
+		 * WP (GPIO0_D1, active-high): weak pull-up at probe =
+		 * write-protected by default. Unlock transiently from
+		 * userspace before writing: gpioset gpiochip0 25=0,
+		 * then =1 to re-lock.
+		 */
+		pinctrl-names = "default";
+		pinctrl-0 = <&eeprom_wp_pu>;
 	};
 
 	pcf85063: rtc@51 {
@@ -478,6 +486,12 @@
 	rtc_pinctrl {
 		rtc_int: rtc-int {
 			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+	};
+
+	eeprom_pinctrl {
+		eeprom_wp_pu: eeprom-wp-pu {
+			rockchip,pins = <0 RK_PD1 RK_FUNC_GPIO &pcfg_pull_up>;
 		};
 	};
 };


### PR DESCRIPTION
## Summary

Add support for the Seeed Studio **reComputer Industrial RK3576** (SoM + industrial carrier).

One commit: `arm64: dts: rockchip: add reComputer Industrial RK3576 (SoM + carrier)` — `rk3576-recomputer-som.dtsi` (SoM common: FCS960KAAMD WiFi/BT, GMAC0 RTL8211F, I2C2 EEPROM/RTC, HDMI, USB1) + eMMC/SPI-NOR storage variants + industrial carrier dts: USB5744 hub (2x USB3 Type-A + CH344 2x RS485/RS232 + Mini PCIe 4G), GMAC1 MAE0621A RJ45 (PoE 802.3af), isolated CAN1 (TPT71044), LoRa SX1261 on SPI3_M0 (spidev until an SX126x SPI driver lands), ES8311 audio, AW35615/FUSB302 Type-C CC with 4-lane DP alt-mode, M.2 Key-M NVMe, RGB LED, SGM706B gpio-watchdog, isolated DI/DO, buzzer, boot-mode ADC key. No fan, no TF slot. The plain 16550 `ttyS0` console is used, so `fiq-debugger` (UART0, serial-id 0) is disabled to avoid the probe conflict.

## Verified on hardware

- GMAC1 RGMII delays calibrated on-board: `tx_delay`/`rx_delay` = `0x1a` → clean RX (0 CRC errors), 0% ping loss; RX delay `0x3f` and PHY-side delay modes (`rgmii-rxid`/`rgmii-id`) fail RX with CRC errors
- SARADC0 boot-mode divider measured: ~1614 mV normal / ~15 mV maskrom, key threshold set at the 800 mV midpoint
- DTB compiles clean with the vendor dtc (only 2 cosmetic warnings, both inherited from the devkit's fusb302 port pattern); checkpatch: 0 errors

## Review feedback addressed

- Compatible string normalized to `seeed,recomputer-industrial-rk3576` (no spaces, `vendor,model` form)
- GMAC1 PHY node comment rewritten to not reference an out-of-tree driver: LEDs fall back to the strap default under the generic C22 driver
