### PR TITLE
arm64: dts: rockchip: fixes for Mixtile boards (Edge2 and Blade3)

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-mixtile-edge2.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-mixtile-edge2.dts
@@ -534,6 +534,8 @@
 		wakeup-source;
 		#clock-cells = <1>;
 		clock-output-names = "rk808-clkout1", "rk808-clkout2";
+		/* clkout2 is the 32.768kHz LPO for the AP6275S WiFi/BT module */
+		rockchip,clk-32k-always-on;
 		//fb-inner-reg-idxs = <2>;
 		/* 1: rst regs (default in codes), 0: rst the pmic */
 		pmic-reset-func = <0>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-blade3-v101-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blade3-v101-linux.dts
@@ -24,6 +24,11 @@
 	compatible = "rockchip,rk3588-blade3-v101-linux", "rockchip,rk3588";
 	/delete-node/ chosen;
 
+	aliases {
+		ethernet0 = &rtl_eth0;
+		ethernet1 = &rtl_eth1;
+	};
+
 	/* If hdmirx node is disabled, delete the reserved-memory node here. */
 	reserved-memory {
 		#address-cells = <2>;
@@ -978,6 +983,63 @@
 &pcie2x1l0 { // combphy1, to ASM1182e
 	reset-gpios = <&gpio1 RK_PB4 GPIO_ACTIVE_HIGH>;
 	status = "okay";
+
+	/*
+	 * Describe the fixed PCIe topology on this port so the two soldered
+	 * RTL8125 2.5GbE controllers get stable ethernet0/ethernet1 aliases and
+	 * can take a fixed/nvmem MAC. Mirrors the enumerated hierarchy (domain
+	 * 0002 in lspci):
+	 *   20:00.0 RK3588 root port
+	 *     21:00.0 ASM1182e switch upstream
+	 *       22:03.0 downstream port -> 23:00.0 RTL8125 #0 (eth0)
+	 *       22:07.0 downstream port -> 24:00.0 RTL8125 #1 (eth1)
+	 * reg encodes the config address (bus << 16 | dev << 11 | fn << 8).
+	 */
+	pcie@0,0 {
+		reg = <0x200000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+		device_type = "pci";
+		bus-range = <0x20 0x2f>;
+
+		pcie@0,0 { // ASM1182e switch upstream port (21:00.0)
+			reg = <0x210000 0 0 0 0>;
+			#address-cells = <3>;
+			#size-cells = <2>;
+			ranges;
+			device_type = "pci";
+			bus-range = <0x22 0x24>;
+
+			pcie@3,0 { // ASM1182e downstream port (22:03.0)
+				reg = <0x221800 0 0 0 0>;
+				#address-cells = <3>;
+				#size-cells = <2>;
+				ranges;
+				device_type = "pci";
+				bus-range = <0x23 0x23>;
+
+				rtl_eth0: ethernet@0,0 { // RTL8125 #0 (23:00.0)
+					compatible = "pci10ec,8125";
+					reg = <0x230000 0 0 0 0>;
+				};
+			};
+
+			pcie@7,0 { // ASM1182e downstream port (22:07.0)
+				reg = <0x223800 0 0 0 0>;
+				#address-cells = <3>;
+				#size-cells = <2>;
+				ranges;
+				device_type = "pci";
+				bus-range = <0x24 0x24>;
+
+				rtl_eth1: ethernet@0,0 { // RTL8125 #1 (24:00.0)
+					compatible = "pci10ec,8125";
+					reg = <0x240000 0 0 0 0>;
+				};
+			};
+		};
+	};
 };
 
 &pcie2x1l1 { // combphy2, to miniPCIe socket

--- a/arch/arm64/boot/dts/rockchip/rk3588-blade3-v101-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blade3-v101-linux.dts
@@ -179,6 +179,18 @@
 		regulator-max-microvolt = <12000000>;
 	};
 
+	vcc5v0_fan: vcc5v0-fan {
+		compatible = "regulator-fixed";
+		regulator-name = "vcc5v0_fan";
+		regulator-min-microvolt = <5000000>;
+		regulator-max-microvolt = <5000000>;
+		enable-active-high;
+		gpio = <&gpio3 RK_PC0 GPIO_ACTIVE_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&fan_en_pin>;
+		vin-supply = <&vcc5v0_sys>;
+	};
+
 	vcc5v0_sys: vcc5v0-sys {
 		compatible = "regulator-fixed";
 		regulator-name = "vcc5v0_sys";
@@ -227,7 +239,10 @@
 		pulses-per-revolution = <2>;
 
 		#cooling-cells = <2>;
-		pwms = <&pwm8 0 250000 0>;
+		pwms = <&pwm8 0 40000 0>; /* 40000 meant for Noctua */
+		fan-supply = <&vcc5v0_fan>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&fan_tach_pin>; /* for the pull-up on the tacho input */
 		cooling-levels = <0 35 70 100 125 150>;
 		rockchip,temp-trips = <
 			30000   1
@@ -1059,6 +1074,16 @@ status = "okay";
 };
 
 &pinctrl {
+	fan {
+		fan_tach_pin: fan-tach-pin {
+			rockchip,pins = <3 RK_PB1 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+
+		fan_en_pin: fan-en-pin {
+			rockchip,pins = <3 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+
 	sdmmc {
 		sd_s0_pwr: sd-s0-pwr {
 			rockchip,pins = <0 RK_PB7 RK_FUNC_GPIO &pcfg_pull_up>;


### PR DESCRIPTION
> - Blade3: RTL8125:  I've been doing this for mainline for a while (it's on a v4 or v5 on lore, still pending) but it also works for vendor kernel (with mainline u-boot). The Blade3 has a PCIe switch that is a bit hairier to describe, but works

> - Blade3: fan: the tacho pin needs a pull up. The schematic shows a fan-en regulator that wasn't here.

> - Edge2: fix for Wifi.