### PR TITLE
arm64: dts: rockchip: describe PCIe RTL8125 Ethernet on reComputer RK3588

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-recomputer-rk3588-devkit.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-recomputer-rk3588-devkit.dts
@@ -27,6 +27,11 @@
 
 	/delete-node/ chosen;
 
+	aliases {
+		ethernet0 = &rtl_eth0;
+		ethernet1 = &rtl_eth1;
+	};
+
 	adc-keys {
 		compatible = "adc-keys";
 		io-channels = <&saradc 1>;
@@ -890,16 +895,31 @@
     status = "okay";
 };
 
-/* phy1 - right ethernet port PCIE20_1_TXP */
+/* phy1 - right ethernet port PCIE20_1_TXP, marked ETH1 on the enclosure */
 &pcie2x1l0 {
 	reset-gpios = <&gpio4 RK_PA5 GPIO_ACTIVE_HIGH>;
-	/* r8125 Ethernet LED configuration:
-	 * LED0 (yellow): blink on traffic at all link speeds
-	 * LED3 (green): solid on at all link speeds
-	 */
-	realtek,led-data = <0x18 0x022B 0x96 0x002B>;
 	vpcie3v3-supply = <&vcc5v0_usb_eth>;
 	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x200000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+		device_type = "pci";
+		bus-range = <0x21 0x2f>;
+
+		rtl_eth1: ethernet@0,0 {
+			compatible = "pci10ec,8125";
+			reg = <0x210000 0 0 0 0>;
+			local-mac-address = [00 00 00 00 00 00];
+			/* r8125 Ethernet LED configuration:
+			 * LED0 (yellow): blink on traffic at all link speeds
+			 * LED3 (green): solid on at all link speeds
+			 */
+			realtek,led-data = <0x18 0x022B 0x96 0x002B>;
+		};
+	};
 };
 
 /* phy2 - M.KEY socket  PCIE20_2_TXP */
@@ -909,16 +929,31 @@
 	status = "okay";
 };
 
-/* phy0 - left ethernet port PCIE20_0_TXP */
+/* phy0 - left ethernet port PCIE20_0_TXP, marked ETH0 on the enclosure */
 &pcie2x1l2 {
 	reset-gpios = <&gpio3 RK_PD0 GPIO_ACTIVE_HIGH>;
-	/* r8125 Ethernet LED configuration:
-	 * LED0 (yellow): blink on traffic at all link speeds
-	 * LED3 (green): solid on at all link speeds
-	 */
-	realtek,led-data = <0x18 0x022B 0x96 0x002B>;
 	vpcie3v3-supply = <&vcc5v0_usb_eth>;
 	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x400000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+		ranges;
+		device_type = "pci";
+		bus-range = <0x41 0x4f>;
+
+		rtl_eth0: ethernet@0,0 {
+			compatible = "pci10ec,8125";
+			reg = <0x410000 0 0 0 0>;
+			local-mac-address = [00 00 00 00 00 00];
+			/* r8125 Ethernet LED configuration:
+			 * LED0 (yellow): blink on traffic at all link speeds
+			 * LED3 (green): solid on at all link speeds
+			 */
+			realtek,led-data = <0x18 0x022B 0x96 0x002B>;
+		};
+	};
 };
 
 


### PR DESCRIPTION
> RTL8125: I've been doing this for mainline for a while (it's on a v4 or v5 on lore, still pending) but it also works for vendor kernel (with mainline u-boot). 

The Seeed reComputer RK3588 Dev Kit carries two on-board Realtek RTL8125 NICs behind pcie2x1l0 and pcie2x1l2.

Describe the fixed function nodes, each with a placeholder local-mac-address, and attach ethernet0/ethernet1 aliases, so that U-Boot's fdt_fixup_ethernet() can fill in the MAC from its ethaddr/eth1addr env. The on-NIC EEPROMs on this board are not pre-programmed with a unique MAC, so this gives a stable MAC across boots that both U-Boot and the kernel agree on.

Number the aliases after the labels silkscreened on the enclosure rather than after PCI enumeration order: the port marked ETH0 is the one behind pcie2x1l2, which enumerates as domain 4 bus 0x41, and ETH1 is behind pcie2x1l0, domain 2 bus 0x21. Enumeration order would have numbered them the other way around, leaving the kernel naming the port marked ETH0 end1.

Move the vendor-specific realtek,led-data property down from the host bridge node into the new ethernet@0,0 function node on each port. This is required, not cosmetic: rtl8125_parse_dt_led_config() locates its configuration by walking up the device parent chain from the PCI device and taking the first non-NULL of_node it finds. Until now the PCI devices had no DT nodes at all, so that walk ran all the way up to the host bridge's platform device and picked up the property from the pcie2x1l0/pcie2x1l2 nodes. Adding the function nodes makes pci_set_of_node() bind ethernet@0,0 to the NIC itself, so the walk now terminates on the very first hop and never reaches the host bridge. Leaving the property where it was would have silently dropped the LED configuration, with the driver finding an of_node that simply lacks the property and returning early.


Assisted-by: Claude-Code:claude-opus-5