### PR TITLE
arm64: dts: rockchip: add FriendlyELEC NanoPi R28S

### DIFF
--- a/arch/arm64/boot/dts/rockchip/Makefile
+++ b/arch/arm64/boot/dts/rockchip/Makefile
@@ -479,6 +479,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-hinlink-h28k.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-hinlink-ht2.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-mangopi-m28k.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-nanopi-rev01.dtb
+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-nanopi-rev03.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-radxa-e20c.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-radxa-e24c-spi.dtb
 dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3528-radxa-e24c.dtb

--- a/arch/arm64/boot/dts/rockchip/rk3528-nanopi-common.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3528-nanopi-common.dtsi
@@ -623,10 +623,7 @@
 
 &usbdrd_dwc3 {
 	dr_mode = "otg";
-	maximum-speed = "high-speed";
 	extcon = <&usb2phy>;
-	phys = <&u2phy_otg>;
-	phy-names = "usb2-phy";
 	snps,dis_u2_susphy_quirk;
 	snps,usb2-lpm-disable;
 	status = "okay";

--- a/arch/arm64/boot/dts/rockchip/rk3528-nanopi-rev03.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3528-nanopi-rev03.dts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: (GPL-2.0+ OR MIT)
 /*
- * Copyright (c) 2024 FriendlyElec Computer Tech. Co., Ltd.
+ * Copyright (c) 2026 FriendlyElec Computer Tech. Co., Ltd.
  * (http://www.friendlyelec.com)
  */
 
@@ -9,8 +9,13 @@
 #include "rk3528-nanopi-common.dtsi"
 
 / {
-	model = "FriendlyElec NanoPi Zero2";
-	compatible = "friendlyelec,nanopi-zero2", "rockchip,rk3528";
+	model = "FriendlyElec NanoPi R28S";
+	compatible = "friendlyelec,nanopi-r28s", "rockchip,rk3528";
+
+	aliases {
+		ethernet0 = &gmac1;
+		ethernet1 = &r8111h;
+	};
 
 	leds: gpio-leds {
 		compatible = "gpio-leds";
@@ -23,11 +28,18 @@
 			pinctrl-0 = <&sys_led_pin>;
 		};
 
-		user_led: led-1 {
+		usr_led1: led-1 {
 			gpios = <&gpio4 RK_PB1 GPIO_ACTIVE_HIGH>;
-			label = "user_led";
+			label = "led1";
 			pinctrl-names = "default";
-			pinctrl-0 = <&user_led_pin>;
+			pinctrl-0 = <&usr_led1_pin>;
+		};
+
+		usr_led2: led-2 {
+			gpios = <&gpio4 RK_PB3 GPIO_ACTIVE_HIGH>;
+			label = "led2";
+			pinctrl-names = "default";
+			pinctrl-0 = <&usr_led2_pin>;
 		};
 	};
 
@@ -45,24 +57,33 @@
 		};
 	};
 
-	adc2_keys: adc2-keys {
-		compatible = "adc-keys";
-		io-channels = <&saradc 1>;
-		io-channel-names = "buttons";
-		keyup-threshold-microvolt = <1800000>;
-		poll-interval = <100>;
+	gpio_keys: gpio-keys {
+		compatible = "gpio-keys";
+		pinctrl-names = "default";
+		pinctrl-0 = <&key1_pin>;
 
-		vol-up-key {
-			label = "volume up";
-			linux,code = <KEY_VOLUMEUP>;
-			press-threshold-microvolt = <1750>;
+		button@1 {
+			debounce-interval = <50>;
+			gpios = <&gpio4 RK_PB2 GPIO_ACTIVE_LOW>;
+			label = "K1";
+			linux,code = <BTN_1>;
+			wakeup-source;
 		};
+	};
+
+	sdio_pwrseq: sdio-pwrseq {
+		compatible = "mmc-pwrseq-simple";
+		pinctrl-names = "default";
+		pinctrl-0 = <&wifi_enable_h>;
+
+		post-power-on-delay-ms = <50>;
+		reset-gpios = <&gpio1 RK_PC2 GPIO_ACTIVE_LOW>;
 	};
 };
 
 &mach {
-	hwrev = <1>;
-	model = "NanoPi Zero2";
+	hwrev = <3>;
+	model = "NanoPi R28S";
 };
 
 &gmac1 {
@@ -101,11 +122,23 @@
 &pcie2x1 {
 	pinctrl-names = "default";
 	pinctrl-0 = <&pciem1_pins>;
-	reset-gpios = <&gpio1 RK_PA2 GPIO_ACTIVE_HIGH>;
+	reset-gpios = <&gpio4 RK_PC0 GPIO_ACTIVE_HIGH>;
 	resets = <&cru SRST_RESETN_PCIE_POWER_UP>, <&cru SRST_PRESETN_PCIE>;
 	reset-names = "pcie", "periph";
 	rockchip,skip-scan-in-resume;
+	rockchip,skip-hw-retry;
 	status = "okay";
+
+	pcie@0,0 {
+		reg = <0x00000000 0 0 0 0>;
+		#address-cells = <3>;
+		#size-cells = <2>;
+
+		r8111h: pcie@0,0 {
+			reg = <0x000000 0 0 0 0>;
+			local-mac-address = [ 00 00 00 00 00 00 ];
+		};
+	};
 };
 
 &combphy_pu {
@@ -134,12 +167,8 @@
 
 &pciem1_pins {
 	rockchip,pins =
-		/* pcie_clkreqn_m1 */
-		<1 RK_PA0 4 &pcfg_pull_none>,
-		/* pcie_waken_m1 */
-		<1 RK_PA1 4 &pcfg_pull_none>,
 		/* pcie_reset_gpio */
-		<1 RK_PA2 RK_FUNC_GPIO &pcfg_pull_none>;
+		<4 RK_PC0 RK_FUNC_GPIO &pcfg_pull_none>;
 };
 
 &pinctrl {
@@ -148,8 +177,12 @@
 			rockchip,pins = <4 RK_PB0 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 
-		user_led_pin: user-led-pin {
+		usr_led1_pin: usr-led1-pin {
 			rockchip,pins = <4 RK_PB1 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+
+		usr_led2_pin: usr-led2-pin {
+			rockchip,pins = <4 RK_PB3 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
 	};
 
@@ -157,6 +190,48 @@
 		rtc_int: rtc-int {
 			rockchip,pins = <4 RK_PC1 RK_FUNC_GPIO &pcfg_pull_none>;
 		};
+	};
+
+	gpio-key {
+		key1_pin: key1-pin {
+			rockchip,pins = <4 RK_PB2 RK_FUNC_GPIO &pcfg_pull_up>;
+		};
+	};
+
+	sdio-pwrseq {
+		wifi_enable_h: wifi-enable-h {
+			rockchip,pins = <1 RK_PC2 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+};
+
+&sdio0 {
+	max-frequency = <150000000>;
+	no-sd;
+	no-mmc;
+	supports-sdio;
+	bus-width = <4>;
+	disable-wp;
+	cap-sd-highspeed;
+	cap-sdio-irq;
+	keep-power-in-suspend;
+	non-removable;
+	mmc-pwrseq = <&sdio_pwrseq>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&sdio0_bus4 &sdio0_cmd &sdio0_clk>;
+	sd-uhs-sdr104;
+	vqmmc-supply = <&vdd_1v8_s3>;
+	status = "okay";
+};
+
+&uart2 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&uart2m1_xfer &uart2m1_ctsn &uart2m1_rtsn>;
+	status = "okay";
+
+	bluetooth {
+		compatible = "cvte,aic8800-bt";
+		device-wake-gpios = <&gpio1 RK_PB4 GPIO_ACTIVE_HIGH>;
 	};
 };
 

--- a/drivers/bluetooth/Kconfig
+++ b/drivers/bluetooth/Kconfig
@@ -280,6 +280,17 @@ config BT_HCIUART_ROCKCHIP
 
 	  Say Y here to compile support for Rockchip RK96x protocol.
 
+config BT_HCIUART_AIC
+	bool "AIC H4 protocol support"
+	depends on BT_HCIUART
+	depends on BT_HCIUART_SERDEV
+	select BT_HCIUART_H4
+	help
+	  This is a simple H4 protocol based on Marvell protocol for AIC8800
+	  Bluetooth controller to replace use of hciattach any.
+
+	  Say Y here to compile support for HCI AIC protocol.
+
 config BT_HCIBCM203X
 	tristate "HCI BCM203x USB driver"
 	depends on USB

--- a/drivers/bluetooth/Makefile
+++ b/drivers/bluetooth/Makefile
@@ -50,6 +50,7 @@ hci_uart-$(CONFIG_BT_HCIUART_QCA)	+= hci_qca.o
 hci_uart-$(CONFIG_BT_HCIUART_AG6XX)	+= hci_ag6xx.o
 hci_uart-$(CONFIG_BT_HCIUART_MRVL)	+= hci_mrvl.o
 hci_uart-$(CONFIG_BT_HCIUART_ROCKCHIP)	+= hci_rk.o
+hci_uart-$(CONFIG_BT_HCIUART_AIC)	+= hci_aic.o
 hci_uart-objs				:= $(hci_uart-y)
 
 obj-$(CONFIG_BT_HCIBTUSB_RTLBTUSB)	+= rtk_btusb.o

--- a/drivers/bluetooth/hci_aic.c
+++ b/drivers/bluetooth/hci_aic.c
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * Bluetooth HCI UART driver for aic8800 devices
+ *
+ *  Copyright (c) 2026 FriendlyElec Computer Tech. Co., Ltd.
+ *  (http://www.friendlyelec.com)
+ *
+ * Based on hci_mrvl.c
+ *
+ *  Copyright (C) 2016  Marvell International Ltd.
+ *  Copyright (C) 2016  Intel Corporation
+ */
+
+#include <linux/kernel.h>
+#include <linux/errno.h>
+#include <linux/skbuff.h>
+#include <linux/gpio/consumer.h>
+#include <linux/module.h>
+#include <linux/tty.h>
+#include <linux/of.h>
+#include <linux/serdev.h>
+
+#include <net/bluetooth/bluetooth.h>
+#include <net/bluetooth/hci_core.h>
+
+#include "hci_uart.h"
+
+struct aic_serdev {
+	struct hci_uart hu;
+
+	struct sk_buff *rx_skb;
+	struct sk_buff_head txq;
+};
+
+static int aic_open(struct hci_uart *hu)
+{
+	struct aic_serdev *aic = hu->priv;
+
+	BT_DBG("hu %p", hu);
+
+	if (!hu->serdev || !hci_uart_has_flow_control(hu))
+		return -EOPNOTSUPP;
+
+	skb_queue_head_init(&aic->txq);
+
+	return 0;
+}
+
+static int aic_close(struct hci_uart *hu)
+{
+	struct aic_serdev *aic = hu->priv;
+
+	BT_DBG("hu %p", hu);
+
+	skb_queue_purge(&aic->txq);
+	kfree_skb(aic->rx_skb);
+
+	return 0;
+}
+
+static int aic_flush(struct hci_uart *hu)
+{
+	struct aic_serdev *aic = hu->priv;
+
+	BT_DBG("hu %p", hu);
+
+	skb_queue_purge(&aic->txq);
+
+	return 0;
+}
+
+static int aic_enqueue(struct hci_uart *hu, struct sk_buff *skb)
+{
+	struct aic_serdev *aic = hu->priv;
+
+	BT_DBG("hu %p skb %p", hu, skb);
+
+	/* Prepend skb with frame type */
+	memcpy(skb_push(skb, 1), &hci_skb_pkt_type(skb), 1);
+	skb_queue_tail(&aic->txq, skb);
+
+	return 0;
+}
+
+static struct sk_buff *aic_dequeue(struct hci_uart *hu)
+{
+	struct aic_serdev *aic = hu->priv;
+
+	return skb_dequeue(&aic->txq);
+}
+
+static const struct h4_recv_pkt aic_recv_pkts[] = {
+	{ H4_RECV_ACL,   .recv = hci_recv_frame },
+	{ H4_RECV_SCO,   .recv = hci_recv_frame },
+	{ H4_RECV_EVENT, .recv = hci_recv_frame },
+	{ H4_RECV_ISO,   .recv = hci_recv_frame },
+};
+
+static int aic_recv(struct hci_uart *hu, const void *data, int count)
+{
+	struct aic_serdev *aic = hu->priv;
+
+	if (!test_bit(HCI_UART_REGISTERED, &hu->flags))
+		return -EUNATCH;
+
+	aic->rx_skb = h4_recv_buf(hu->hdev, aic->rx_skb, data, count,
+				  aic_recv_pkts,
+				  ARRAY_SIZE(aic_recv_pkts));
+	if (IS_ERR(aic->rx_skb)) {
+		int err = PTR_ERR(aic->rx_skb);
+
+		bt_dev_err(hu->hdev, "Frame reassembly failed (%d)", err);
+		aic->rx_skb = NULL;
+		return err;
+	}
+
+	return count;
+}
+
+static int aic_setup(struct hci_uart *hu)
+{
+	int err;
+
+	/* The firmware might be loaded by the Wifi driver over SDIO. We wait
+	 * up to 10s for the CTS to go up. Afterward, we know that the firmware
+	 * is ready.
+	 */
+	err = serdev_device_wait_for_cts(hu->serdev, true, 10000);
+	if (err) {
+		bt_dev_err(hu->hdev, "Wait for CTS failed with %d\n", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static const struct hci_uart_proto aic_proto = {
+	.id		= HCI_UART_AIC,
+	.name		= "AIC (H4)",
+	.init_speed	= 1500000,
+	.open		= aic_open,
+	.close		= aic_close,
+	.flush		= aic_flush,
+	.setup		= aic_setup,
+	.recv		= aic_recv,
+	.enqueue	= aic_enqueue,
+	.dequeue	= aic_dequeue,
+};
+
+static int aic_serdev_probe(struct serdev_device *serdev)
+{
+	struct device *dev = &serdev->dev;
+	struct aic_serdev *aicdev;
+
+	aicdev = devm_kzalloc(dev, sizeof(*aicdev), GFP_KERNEL);
+	if (!aicdev)
+		return -ENOMEM;
+
+	aicdev->hu.priv = aicdev;
+	aicdev->hu.serdev = serdev;
+	serdev_device_set_drvdata(serdev, aicdev);
+
+	return hci_uart_register_device(&aicdev->hu, &aic_proto);
+}
+
+static void aic_serdev_remove(struct serdev_device *serdev)
+{
+	struct aic_serdev *aicdev = serdev_device_get_drvdata(serdev);
+
+	hci_uart_unregister_device(&aicdev->hu);
+}
+
+#ifdef CONFIG_OF
+static const struct of_device_id aic_bluetooth_of_match[] = {
+	{ .compatible = "cvte,aic8800-bt" },
+	{ },
+};
+MODULE_DEVICE_TABLE(of, aic_bluetooth_of_match);
+#endif
+
+static struct serdev_device_driver aic_serdev_driver = {
+	.probe = aic_serdev_probe,
+	.remove = aic_serdev_remove,
+	.driver = {
+		.name = "hci_uart_aic",
+		.of_match_table = of_match_ptr(aic_bluetooth_of_match),
+	},
+};
+
+int __init aic_init(void)
+{
+	serdev_device_driver_register(&aic_serdev_driver);
+
+	return hci_uart_register_proto(&aic_proto);
+}
+
+int __exit aic_deinit(void)
+{
+	serdev_device_driver_unregister(&aic_serdev_driver);
+
+	return hci_uart_unregister_proto(&aic_proto);
+}

--- a/drivers/bluetooth/hci_ldisc.c
+++ b/drivers/bluetooth/hci_ldisc.c
@@ -900,6 +900,9 @@ static int __init hci_uart_init(void)
 #ifdef CONFIG_BT_HCIUART_ROCKCHIP
 	rkbt_init();
 #endif
+#ifdef CONFIG_BT_HCIUART_AIC
+	aic_init();
+#endif
 
 	return 0;
 }
@@ -938,6 +941,9 @@ static void __exit hci_uart_exit(void)
 #endif
 #ifdef CONFIG_BT_HCIUART_ROCKCHIP
 	rkbt_deinit();
+#endif
+#ifdef CONFIG_BT_HCIUART_AIC
+	aic_deinit();
 #endif
 
 	tty_unregister_ldisc(&hci_uart_ldisc);

--- a/drivers/bluetooth/hci_uart.h
+++ b/drivers/bluetooth/hci_uart.h
@@ -20,7 +20,7 @@
 #define HCIUARTGETFLAGS		_IOR('U', 204, int)
 
 /* UART protocols */
-#define HCI_UART_MAX_PROTO	13
+#define HCI_UART_MAX_PROTO	14
 
 #define HCI_UART_H4	0
 #define HCI_UART_BCSP	1
@@ -35,6 +35,7 @@
 #define HCI_UART_NOKIA	10
 #define HCI_UART_MRVL	11
 #define HCI_UART_RK96X	12
+#define HCI_UART_AIC	13
 
 #define HCI_UART_RAW_DEVICE	0
 #define HCI_UART_RESET_ON_INIT	1
@@ -206,4 +207,9 @@ int mrvl_deinit(void);
 #ifdef CONFIG_BT_HCIUART_ROCKCHIP
 int rkbt_init(void);
 int rkbt_deinit(void);
+#endif
+
+#ifdef CONFIG_BT_HCIUART_AIC
+int aic_init(void);
+int aic_deinit(void);
 #endif


### PR DESCRIPTION
## Description

Add Device Tree support for the FriendlyELEC NanoPi R28S based on the
Rockchip RK3528A SoC.

The new DTS describes:

- RK3528A SoC with 1 GB LPDDR4
- eMMC and microSD
- GMAC1 with RTL8211F PHY
- PCIe RTL8111H Gigabit Ethernet
- AIC8800D80 Wi-Fi 6 and Bluetooth module
- HYM8563 RTC
- GPIO LEDs
- GPIO user button
- USB OTG

## Changes

- Add `rk3528-nanopi-rev03.dts`
- Register `rk3528-nanopi-rev03.dtb` in the Rockchip DTS Makefile
- Synchronize the shared RK3528 NanoPi DTS definitions with the
  FriendlyElec vendor source

## Source

The R28S Device Tree is based on the following FriendlyELEC vendor DTS: [friendlyarm/kernel-rockchip](https://github.com/friendlyarm/kernel-rockchip/blob/ee640c5344b13a0a317436e2357df01af8268ce7/arch/arm64/boot/dts/rockchip/rk3528-nanopi-rev03.dts)

The vendor DTS was adapted to the Armbian `linux-rockchip` tree and
synchronized with the existing RK3528 NanoPi DTS definitions.

## DTS revision

In the FriendlyElec vendor source, the RK3528 NanoPi board revisions are
mapped as follows:

- `rk3528-nanopi-rev01.dts`: NanoPi Zero2
- `rk3528-nanopi-rev02.dts`: NanoPi NEO3 Plus
- `rk3528-nanopi-rev03.dts`: NanoPi R28S

The Armbian `linux-rockchip` branch currently does not contain
`rk3528-nanopi-rev02.dts`. It is intentionally not added in this change,
as NEO3 Plus support is outside the scope of this R28S-specific patch.
Only the R28S `rev03` DTS is added here.

## Testing

- Built `rk3528-nanopi-rev03.dtb` successfully
- Verified that the DTS compiles against the `rk-6.1-rkr5.1` vendor
  kernel tree