### PR TITLE
BACKPORT rkr5.1: ARM: dts: rockchip: rk3502: add 2M alignment for CMA address

### DIFF
--- a/arch/arm/boot/dts/rk3502.dtsi
+++ b/arch/arm/boot/dts/rk3502.dtsi
@@ -431,6 +431,7 @@
 			reusable;
 			size = <0x0>;
 			linux,cma-default;
+			alignment = <0x00200000>;
 		};
 
 		drm_logo: drm-logo@0 {


### PR DESCRIPTION
BACKPORT cherry-picked cleanly from `rk-6.1-rkr7.2` 2a1077bbc632219c739cda0f316ed931f7768b6a

Fixes boot issues on some RK3506 boards (depending on CMA size, ram size, etc) by explicitly setting 2M alignment for CMA allocations.

Tested with:
- `luckfox-lyra-zero-w` (RK3506B)
- `ebyte-ecb41-pge` (RK3506G2)
