### PR TITLE
arm64: dts: rockchip: mixtile-edge2: fix Bluetooth wake GPIOs and enable eMMC HS400ES

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3568-mixtile-edge2.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-mixtile-edge2.dts
@@ -994,6 +994,8 @@
 	supports-emmc;
 	non-removable;
 	max-frequency = <200000000>;
+	mmc-hs400-1_8v;
+	mmc-hs400-enhanced-strobe;
 	status = "okay";
 };
 

--- a/arch/arm64/boot/dts/rockchip/rk3568-mixtile-edge2.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3568-mixtile-edge2.dts
@@ -306,11 +306,11 @@
 		//wifi-bt-power-toggle;
 		uart_rts_gpios = <&gpio2 RK_PB1 GPIO_ACTIVE_LOW>;
 		pinctrl-names = "default", "rts_gpio";
-		pinctrl-0 = <&uart8m0_rtsn>;
+		pinctrl-0 = <&uart8m0_rtsn &bt_enable &bt_host_wake &bt_wake>;
 		pinctrl-1 = <&uart8_gpios>;
 		BT,reset_gpio    = <&gpio3 RK_PA0 GPIO_ACTIVE_HIGH>;
-		BT,wake_gpio     = <&gpio3 RK_PA1 GPIO_ACTIVE_HIGH>;
-		BT,wake_host_irq = <&gpio3 RK_PA2 GPIO_ACTIVE_HIGH>;
+		BT,wake_gpio     = <&gpio3 RK_PA2 GPIO_ACTIVE_HIGH>;
+		BT,wake_host_irq = <&gpio3 RK_PA1 GPIO_ACTIVE_HIGH>;
 		status = "okay";
 	};
 
@@ -1160,7 +1160,7 @@
 		 };
 
 		 bt_host_wake: bt-host-wake {
-			 rockchip,pins = <3 RK_PA1 RK_FUNC_GPIO &pcfg_pull_down>;
+			 rockchip,pins = <3 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
 		 };
 
 		 bt_wake: bt-wake {


### PR DESCRIPTION
Two device tree defects on the Mixtile Edge 2.

I work at Focalcrest/Mixtile and have the EDGE2 V1.2.1 and
Mixtile-Core-3568 V1.2.1 schematics; both changes come off those.

Verified on an Edge 2 running 6.1.115 built from this branch with
`./compile.sh kernel BOARD=mixtile-edge2 BRANCH=vendor` on
armbian/build v25.11, A/B'd by swapping only the DTB on the same kernel:

- BT: the wake interrupt moves from GPIO3_A2 to GPIO3_A1, where the
  module actually drives it. The three bt_* pinctrl groups also get
  applied for the first time.
- eMMC: timing spec 9 (HS200) -> 10 (HS400 ES). fio 3.41 with O_DIRECT,
  read-only on /dev/mmcblk0: sequential 1M qd8 168 -> 270 MiB/s;
  random 4k qd32 6502 -> 6978 IOPS, i.e. unchanged as expected.

Scope: this PR is only these two. Further fixes for this board (PCIe
supply naming, USB hub reset and M.2 card power modelling, Type-C USB
2.0 capping, unused-node removal) will follow separately, and I'll
mirror this set to rk-6.1-rkr7.2 once it lands here.
