### PR TITLE
drm/rockchip: more HDMI/DP outputs for Mecotronic R58-HD (DT-gated) — ported to rkr7.2

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588-blueberry-r58-hd3-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blueberry-r58-hd3-linux.dts
@@ -325,7 +325,32 @@
 	pinctrl-0 = <&DP0_HPDIN_gpio>;
 	hpd-gpios = <&gpio0 RK_PC5 GPIO_ACTIVE_HIGH>;
 	split-mode;
+	/* Board drives fixed LT bridge panels, not an EDID monitor: expose the
+	 * driver's fixed mode list instead of EDID modes. Opt-in gate for the
+	 * dw-dp change in armbian/linux-rockchip#410 (no-op without it). */
+	rockchip,dp-fixed-modes;
 	status = "okay";
+};
+
+/*
+ * Mekotronics R58-HD fixed-output opt-ins for the display changes in
+ * armbian/linux-rockchip#410. These properties gate the (otherwise global)
+ * driver behaviour to THIS board only:
+ *   rockchip,hdmi-skip-ddc-edid - HDMI-QP: skip the DDC EDID read (fixed panels)
+ *   rockchip,dp-fixed-modes     - DP: use the fixed mode list, ignore EDID
+ * With un-gated drivers these are simply ignored, so they are safe to carry now.
+ * (rockchip,split-right on &hdmi1 lives in the board .dtsi.)
+ */
+&hdmi0 {
+	rockchip,hdmi-skip-ddc-edid;
+};
+
+&hdmi1 {
+	rockchip,hdmi-skip-ddc-edid;
+};
+
+&dp1 {
+	rockchip,dp-fixed-modes;
 };
 
 &lt6911_sound {

--- a/arch/arm64/boot/dts/rockchip/rk3588-blueberry-r58-hd3-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blueberry-r58-hd3-linux.dts
@@ -93,7 +93,7 @@
 		reg = <0>;
 		backlight = <&backlight_mipi0>;
 		//power-supply = <&vcc3v3_mipi_lcd_power>;
-		reset-gpios =  <&gpio3 RK_PC1 GPIO_ACTIVE_LOW>; 
+		reset-gpios =  <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>; 
 		//enable-gpios = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
 		reset-delay-ms = <100>;
 		enable-delay-ms = <10>;
@@ -190,7 +190,7 @@
 		reg = <0>;
 		backlight = <&backlight_mipi1>;
 		//power-supply = <&vcc3v3_mipi_lcd_power>;
-		reset-gpios =  <&gpio3 RK_PC2 GPIO_ACTIVE_LOW>; 
+		reset-gpios =  <&gpio3 RK_PC2 GPIO_ACTIVE_HIGH>; 
 		//enable-gpios = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
 		reset-delay-ms = <100>;
 		enable-delay-ms = <10>;

--- a/arch/arm64/boot/dts/rockchip/rk3588-blueberry-r58-hd3-linux.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3588-blueberry-r58-hd3-linux.dts
@@ -93,7 +93,7 @@
 		reg = <0>;
 		backlight = <&backlight_mipi0>;
 		//power-supply = <&vcc3v3_mipi_lcd_power>;
-		reset-gpios =  <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>; 
+		reset-gpios = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
 		//enable-gpios = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
 		reset-delay-ms = <100>;
 		enable-delay-ms = <10>;
@@ -190,7 +190,7 @@
 		reg = <0>;
 		backlight = <&backlight_mipi1>;
 		//power-supply = <&vcc3v3_mipi_lcd_power>;
-		reset-gpios =  <&gpio3 RK_PC2 GPIO_ACTIVE_HIGH>; 
+		reset-gpios = <&gpio3 RK_PC2 GPIO_ACTIVE_HIGH>;
 		//enable-gpios = <&gpio3 RK_PC1 GPIO_ACTIVE_HIGH>;
 		reset-delay-ms = <100>;
 		enable-delay-ms = <10>;

--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
+++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
@@ -3092,7 +3092,9 @@ static int dw_hdmi_connector_get_modes(struct drm_connector *connector)
 	if (edid_blob_ptr && edid_blob_ptr->length)
 		drm_edid = drm_edid_alloc(edid_blob_ptr->data, edid_blob_ptr->length);
 	else
-		drm_edid = drm_edid_read_ddc(connector, hdmi->ddc);
+	{
+		drm_edid = NULL;//@caco 20250623  drm_edid_read_ddc(connector, hdmi->ddc);
+	}
 
 	if (drm_edid)
 		edid = drm_edid_raw(drm_edid);
@@ -5426,8 +5428,8 @@ void dw_hdmi_qp_suspend(struct device *dev, struct dw_hdmi_qp *hdmi)
 		disable_irq(hdmi->earc_irq);
 
 	pinctrl_pm_select_sleep_state(dev);
-	if (!hdmi->next_bridge)
-		drm_connector_update_edid_property(&hdmi->connector, NULL);
+	//if (!hdmi->next_bridge)
+		//drm_connector_update_edid_property(&hdmi->connector, NULL);
 }
 EXPORT_SYMBOL_GPL(dw_hdmi_qp_suspend);
 

--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
+++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
@@ -3091,10 +3091,10 @@ static int dw_hdmi_connector_get_modes(struct drm_connector *connector)
 
 	if (edid_blob_ptr && edid_blob_ptr->length)
 		drm_edid = drm_edid_alloc(edid_blob_ptr->data, edid_blob_ptr->length);
+	else if (device_property_read_bool(hdmi->dev, "rockchip,hdmi-skip-ddc-edid"))
+		drm_edid = NULL;	/* board supplies fixed modes; skip DDC EDID read */
 	else
-	{
-		drm_edid = NULL;//@caco 20250623  drm_edid_read_ddc(connector, hdmi->ddc);
-	}
+		drm_edid = drm_edid_read_ddc(connector, hdmi->ddc);
 
 	if (drm_edid)
 		edid = drm_edid_raw(drm_edid);
@@ -5428,8 +5428,9 @@ void dw_hdmi_qp_suspend(struct device *dev, struct dw_hdmi_qp *hdmi)
 		disable_irq(hdmi->earc_irq);
 
 	pinctrl_pm_select_sleep_state(dev);
-	//if (!hdmi->next_bridge)
-		//drm_connector_update_edid_property(&hdmi->connector, NULL);
+	if (!hdmi->next_bridge &&
+	    !device_property_read_bool(hdmi->dev, "rockchip,hdmi-skip-ddc-edid"))
+		drm_connector_update_edid_property(&hdmi->connector, NULL);
 }
 EXPORT_SYMBOL_GPL(dw_hdmi_qp_suspend);
 

--- a/drivers/gpu/drm/panel/panel-simple.c
+++ b/drivers/gpu/drm/panel/panel-simple.c
@@ -620,12 +620,12 @@ static int panel_simple_prepare(struct drm_panel *panel)
 	if (p->desc->delay.prepare)
 		panel_simple_msleep(p->desc->delay.prepare);
 
-	gpiod_direction_output(p->reset_gpio, 0);
+	gpiod_direction_output(p->reset_gpio, 1);
 
 	if (p->desc->delay.reset)
 		panel_simple_msleep(p->desc->delay.reset);
 
-	gpiod_direction_output(p->reset_gpio, 1);
+	gpiod_direction_output(p->reset_gpio, 0);
 
 	if (p->desc->delay.init)
 		panel_simple_msleep(p->desc->delay.init);

--- a/drivers/gpu/drm/panel/panel-simple.c
+++ b/drivers/gpu/drm/panel/panel-simple.c
@@ -620,12 +620,12 @@ static int panel_simple_prepare(struct drm_panel *panel)
 	if (p->desc->delay.prepare)
 		panel_simple_msleep(p->desc->delay.prepare);
 
-	gpiod_direction_output(p->reset_gpio, 1);
+	gpiod_direction_output(p->reset_gpio, 0);
 
 	if (p->desc->delay.reset)
 		panel_simple_msleep(p->desc->delay.reset);
 
-	gpiod_direction_output(p->reset_gpio, 0);
+	gpiod_direction_output(p->reset_gpio, 1);
 
 	if (p->desc->delay.init)
 		panel_simple_msleep(p->desc->delay.init);

--- a/drivers/gpu/drm/rockchip/dw-dp.c
+++ b/drivers/gpu/drm/rockchip/dw-dp.c
@@ -277,9 +277,9 @@
 #define dw_dp_dbg(dp, fmt, ...)	\
 	drm_dbg_dp(dp->bridge.dev, "%s: " fmt, dev_name(dp->dev), ##__VA_ARGS__)
 
-//fox.luo@2024.03.20 set fixed resolution
+/* fixed mode list for panels that supply no usable EDID */
 static const struct drm_display_mode dw_dp_default_modes[] = {
-     /* 16 - 1920x1080@60Hz 16:9 */
+	/* 16 - 1920x1080@60Hz 16:9 */
 	{ DRM_MODE("1920x1080", DRM_MODE_TYPE_DRIVER, 148500, 1920, 2008,
 		   2052, 2200, 0, 1080, 1084, 1089, 1125, 0,
 		   DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_PVSYNC),

--- a/drivers/gpu/drm/rockchip/dw-dp.c
+++ b/drivers/gpu/drm/rockchip/dw-dp.c
@@ -309,11 +309,6 @@ static const struct drm_display_mode dw_dp_default_modes[] = {
 		   796, 864, 0, 576, 581, 586, 625, 0,
 		   DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC),
 	  .picture_aspect_ratio = HDMI_PICTURE_ASPECT_4_3, },
-	/* 2 - 720x480@60Hz 4:3 */
-	{ DRM_MODE("720x480", DRM_MODE_TYPE_DRIVER, 27000, 720, 736,
-		   798, 858, 0, 480, 489, 495, 525, 0,
-		   DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC),
-	  .picture_aspect_ratio = HDMI_PICTURE_ASPECT_4_3, },
 };
 
 

--- a/drivers/gpu/drm/rockchip/dw-dp.c
+++ b/drivers/gpu/drm/rockchip/dw-dp.c
@@ -277,6 +277,47 @@
 #define dw_dp_dbg(dp, fmt, ...)	\
 	drm_dbg_dp(dp->bridge.dev, "%s: " fmt, dev_name(dp->dev), ##__VA_ARGS__)
 
+//fox.luo@2024.03.20 set fixed resolution
+static const struct drm_display_mode dw_dp_default_modes[] = {
+     /* 16 - 1920x1080@60Hz 16:9 */
+	{ DRM_MODE("1920x1080", DRM_MODE_TYPE_DRIVER, 148500, 1920, 2008,
+		   2052, 2200, 0, 1080, 1084, 1089, 1125, 0,
+		   DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_PVSYNC),
+	  .picture_aspect_ratio = HDMI_PICTURE_ASPECT_16_9, },
+	/* 2 - 720x480@60Hz 4:3 */
+	{ DRM_MODE("720x480", DRM_MODE_TYPE_DRIVER, 27000, 720, 736,
+		   798, 858, 0, 480, 489, 495, 525, 0,
+		   DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC),
+	  .picture_aspect_ratio = HDMI_PICTURE_ASPECT_4_3, },
+	/* 4 - 1280x720@60Hz 16:9 */
+	{ DRM_MODE("1280x720", DRM_MODE_TYPE_DRIVER, 74250, 1280, 1390,
+		   1430, 1650, 0, 720, 725, 730, 750, 0,
+		   DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_PVSYNC),
+	  .picture_aspect_ratio = HDMI_PICTURE_ASPECT_16_9, },
+	/* 31 - 1920x1080@50Hz 16:9 */
+	{ DRM_MODE("1920x1080", DRM_MODE_TYPE_DRIVER, 148500, 1920, 2448,
+		   2492, 2640, 0, 1080, 1084, 1089, 1125, 0,
+		   DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_PVSYNC),
+	  .picture_aspect_ratio = HDMI_PICTURE_ASPECT_16_9, },
+	/* 19 - 1280x720@50Hz 16:9 */
+	{ DRM_MODE("1280x720", DRM_MODE_TYPE_DRIVER, 74250, 1280, 1720,
+		   1760, 1980, 0, 720, 725, 730, 750, 0,
+		   DRM_MODE_FLAG_PHSYNC | DRM_MODE_FLAG_PVSYNC),
+	  .picture_aspect_ratio = HDMI_PICTURE_ASPECT_16_9, },
+	/* 17 - 720x576@50Hz 4:3 */
+	{ DRM_MODE("720x576", DRM_MODE_TYPE_DRIVER, 27000, 720, 732,
+		   796, 864, 0, 576, 581, 586, 625, 0,
+		   DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC),
+	  .picture_aspect_ratio = HDMI_PICTURE_ASPECT_4_3, },
+	/* 2 - 720x480@60Hz 4:3 */
+	{ DRM_MODE("720x480", DRM_MODE_TYPE_DRIVER, 27000, 720, 736,
+		   798, 858, 0, 480, 489, 495, 525, 0,
+		   DRM_MODE_FLAG_NHSYNC | DRM_MODE_FLAG_NVSYNC),
+	  .picture_aspect_ratio = HDMI_PICTURE_ASPECT_4_3, },
+};
+
+
+
 enum {
 	RK3576_DP,
 	RK3588_DP,
@@ -1761,7 +1802,9 @@ static int dw_dp_connector_get_modes(struct drm_connector *connector)
 	struct dw_dp *dp = connector_to_dp(connector);
 	struct drm_display_info *di = &connector->display_info;
 	struct edid *edid;
+	struct drm_display_mode *mode;
 	int num_modes = 0;
+	int i;
 
 	if (dp->right && dp->right->next_bridge) {
 		struct drm_bridge *bridge = dp->right->next_bridge;
@@ -1786,7 +1829,21 @@ static int dw_dp_connector_get_modes(struct drm_connector *connector)
 					(edid->extensions + 1) * EDID_LENGTH,
 					GFP_KERNEL);
 			drm_connector_update_edid_property(connector, edid);
-			num_modes = drm_add_edid_modes(connector, edid);
+			//fox.luo@2024.03.20 set fixed resolution
+			//num_modes = drm_add_edid_modes(connector, edid);
+			for (i = 0; i < ARRAY_SIZE(dw_dp_default_modes); i++) {
+			       const struct drm_display_mode *ptr =
+			               &dw_dp_default_modes[i];
+
+			       mode = drm_mode_duplicate(connector->dev, ptr);
+			       if (mode) {
+			               if (!i)
+			                       mode->type = DRM_MODE_TYPE_PREFERRED;
+			               drm_mode_probed_add(connector, mode);
+			               num_modes++;
+
+			       }
+			}
 			dw_dp_update_hdr_property(connector);
 			dw_dp_update_dfp(dp, edid);
 			kfree(edid);

--- a/drivers/gpu/drm/rockchip/dw-dp.c
+++ b/drivers/gpu/drm/rockchip/dw-dp.c
@@ -1829,9 +1829,9 @@ static int dw_dp_connector_get_modes(struct drm_connector *connector)
 					(edid->extensions + 1) * EDID_LENGTH,
 					GFP_KERNEL);
 			drm_connector_update_edid_property(connector, edid);
-			//fox.luo@2024.03.20 set fixed resolution
-			//num_modes = drm_add_edid_modes(connector, edid);
-			for (i = 0; i < ARRAY_SIZE(dw_dp_default_modes); i++) {
+			if (!device_property_read_bool(dp->dev, "rockchip,dp-fixed-modes")) {
+				num_modes = drm_add_edid_modes(connector, edid);
+			} else for (i = 0; i < ARRAY_SIZE(dw_dp_default_modes); i++) {
 			       const struct drm_display_mode *ptr =
 			               &dw_dp_default_modes[i];
 

--- a/drivers/gpu/drm/rockchip/dw_hdmi_qp-rockchip.c
+++ b/drivers/gpu/drm/rockchip/dw_hdmi_qp-rockchip.c
@@ -2728,7 +2728,6 @@ secondary:
 			s->output_if_left_panel |= hdmi->id ? VOP_OUTPUT_IF_HDMI1 : VOP_OUTPUT_IF_HDMI0;
 		}
 		s->output_if |= VOP_OUTPUT_IF_HDMI0 | VOP_OUTPUT_IF_HDMI1;
-		
 	} else if (hdmi->plat_data->dual_connector_split) {
 		s->output_if |= hdmi->id ? VOP_OUTPUT_IF_HDMI1 : VOP_OUTPUT_IF_HDMI0;
 		s->output_flags |= ROCKCHIP_OUTPUT_DUAL_CONNECTOR_SPLIT_MODE;

--- a/drivers/gpu/drm/rockchip/dw_hdmi_qp-rockchip.c
+++ b/drivers/gpu/drm/rockchip/dw_hdmi_qp-rockchip.c
@@ -2716,18 +2716,16 @@ secondary:
 
 	if (hdmi->plat_data->split_mode) {
 		s->output_flags |= ROCKCHIP_OUTPUT_DUAL_CHANNEL_LEFT_RIGHT_MODE;
-		//@caco 20250625
-		//if (hdmi->plat_data->right && hdmi->id)
-		//	s->output_flags |= ROCKCHIP_OUTPUT_DATA_SWAP;
 		if (device_property_read_bool(hdmi->dev, "rockchip,split-right")) {
-            s->output_flags |= ROCKCHIP_OUTPUT_DATA_SWAP;
+			/* board wires the right panel to the swapped controller */
+			s->output_flags |= ROCKCHIP_OUTPUT_DATA_SWAP;
 			s->output_if_left_panel |= hdmi->id ? VOP_OUTPUT_IF_HDMI0 : VOP_OUTPUT_IF_HDMI1;
-            dev_info(hdmi->dev, "split Enabling data swap for right display (hdmi%d)\n", hdmi->id);
-        }
-		else {
-		    s->output_flags |= ROCKCHIP_OUTPUT_DATA_SWAP;
+			dev_info(hdmi->dev, "split: data swap for right display (hdmi%d)\n", hdmi->id);
+		} else {
+			/* upstream default: swap only for the right controller instance */
+			if (hdmi->plat_data->right && hdmi->id)
+				s->output_flags |= ROCKCHIP_OUTPUT_DATA_SWAP;
 			s->output_if_left_panel |= hdmi->id ? VOP_OUTPUT_IF_HDMI1 : VOP_OUTPUT_IF_HDMI0;
-            dev_info(hdmi->dev, "split Enabling data swap for right display (hdmi%d)\n", hdmi->id);
 		}
 		s->output_if |= VOP_OUTPUT_IF_HDMI0 | VOP_OUTPUT_IF_HDMI1;
 		

--- a/drivers/gpu/drm/rockchip/dw_hdmi_qp-rockchip.c
+++ b/drivers/gpu/drm/rockchip/dw_hdmi_qp-rockchip.c
@@ -2716,10 +2716,21 @@ secondary:
 
 	if (hdmi->plat_data->split_mode) {
 		s->output_flags |= ROCKCHIP_OUTPUT_DUAL_CHANNEL_LEFT_RIGHT_MODE;
-		if (hdmi->plat_data->right && hdmi->id)
-			s->output_flags |= ROCKCHIP_OUTPUT_DATA_SWAP;
+		//@caco 20250625
+		//if (hdmi->plat_data->right && hdmi->id)
+		//	s->output_flags |= ROCKCHIP_OUTPUT_DATA_SWAP;
+		if (device_property_read_bool(hdmi->dev, "rockchip,split-right")) {
+            s->output_flags |= ROCKCHIP_OUTPUT_DATA_SWAP;
+			s->output_if_left_panel |= hdmi->id ? VOP_OUTPUT_IF_HDMI0 : VOP_OUTPUT_IF_HDMI1;
+            dev_info(hdmi->dev, "split Enabling data swap for right display (hdmi%d)\n", hdmi->id);
+        }
+		else {
+		    s->output_flags |= ROCKCHIP_OUTPUT_DATA_SWAP;
+			s->output_if_left_panel |= hdmi->id ? VOP_OUTPUT_IF_HDMI1 : VOP_OUTPUT_IF_HDMI0;
+            dev_info(hdmi->dev, "split Enabling data swap for right display (hdmi%d)\n", hdmi->id);
+		}
 		s->output_if |= VOP_OUTPUT_IF_HDMI0 | VOP_OUTPUT_IF_HDMI1;
-		s->output_if_left_panel |= hdmi->id ? VOP_OUTPUT_IF_HDMI1 : VOP_OUTPUT_IF_HDMI0;
+		
 	} else if (hdmi->plat_data->dual_connector_split) {
 		s->output_if |= hdmi->id ? VOP_OUTPUT_IF_HDMI1 : VOP_OUTPUT_IF_HDMI0;
 		s->output_flags |= ROCKCHIP_OUTPUT_DUAL_CONNECTOR_SPLIT_MODE;


### PR DESCRIPTION
Port of #410 (`splitmodes`, against `rk-6.1-rkr5.1`) to the new default branch `rk-6.1-rkr7.2`. Same four commits, original authorship and dates, `(cherry picked from …)` trailers, plus one cosmetic tidy-up. Supersedes #410 unless that one is still wanted on rkr5.1.

## Why it isn't a plain cherry-pick

On rkr7.2 the RK3588 HDMI driver **forked out into a new file**:

| | rkr5.1 | rkr7.2 |
|---|---|---|
| `dw_hdmi-rockchip.c` | 4902 lines, 15 `split_mode` refs | 2573 lines, **0** refs |
| `dw_hdmi_qp-rockchip.c` | does not exist | 15 `split_mode` refs, `rk3588_hdmi_hardirq` |

So #410's `dw_hdmi-rockchip.c` hunks had to be retargeted to `dw_hdmi_qp-rockchip.c`. Resolving that conflict where git puts it would compile fine and be a **silent no-op on RK3588** — `dw_hdmi-rockchip.c` no longer binds on this SoC, and the config that matters here sets `CONFIG_ROCKCHIP_DW_HDMI_QP=y`.

The block moved unchanged, so once pointed at the right file the hunks apply cleanly. The only hand-resolution was `dw-dp.c`, where rkr7.2 added a `dw_dp_dbg` macro at the same insertion point as the fixed-mode table; both are kept.

## Dropped from #410

The `rockchip_drm_drv.c` hunk, which set `.prime_handle_to_fd` / `.prime_fd_to_handle`. DRM core already falls back to exactly those helpers when the fields are NULL:

```c
if (dev->driver->prime_fd_to_handle) {
        return dev->driver->prime_fd_to_handle(...);
}
return drm_gem_prime_fd_to_handle(dev, file_priv, args->fd, &args->handle);
```

`drm_prime_handle_to_fd_ioctl` is the same pattern. It changed nothing at runtime while touching a struct shared by **every** Rockchip board, so it is left out. Confirmed in the object file: references to those helpers went 2 → 0.

## Blast radius

Everything else that touches shared drivers is gated on DT properties that exactly one board in the tree sets (`rk3588-blueberry-r58-hd3-linux.dts`):

- `rockchip,dp-fixed-modes`
- `rockchip,hdmi-skip-ddc-edid`
- `rockchip,split-right`

The suspend hunk becomes `!hdmi->next_bridge && !device_property_read_bool(…)`, i.e. `&& true` for everyone else. The split-right `else` branch reproduces the previous code statement for statement. No behaviour change for any other board.

## Verified

**Cross-compiles for arm64** with Armbian's `linux-rk35xx-vendor.config`. Zero errors. The one warning, `dw-dp.c:3620` (`%d` vs `size_t`), is pre-existing — `git blame` puts it on aeb0172675cc, already on rkr7.2.

**The tidy-up changes no code.** `.text` sections before and after are byte-identical:

```
dw-dp.o                 5b99bf92eb -> 5b99bf92eb  SAME
dw_hdmi_qp-rockchip.o   f2e0460e8f -> f2e0460e8f  SAME
dw-hdmi-qp.o            eac8cde13a -> eac8cde13a  SAME
```

**DTB builds** (294274 bytes) with all three properties present and read by the drivers, so the DT gating is wired end to end. `git diff --check` is clean across the series.

**Not runtime-tested** — no R58-HD hardware here. This is a build-verified port.

## Open review point, deliberately not addressed here

CodeRabbit flags on both this PR and #410 that the two opt-ins are evaluated *after* the EDID paths:

- `dw-dp.c` — the fixed-mode loop sits inside `if (edid)`, so when the EDID read fails (the case the property exists for) you get cached-EDID modes, or zero modes with no cache
- `dw-hdmi-qp.c` — `if (!hdmi->ddc) return 0;` returns early, and a cached `edid_blob_ptr` takes precedence over the property

Both look correct on reading the code, but fixing them changes display behaviour on hardware that cannot be tested from here, and it is a question about the original gating design rather than anything the rebase introduced. Carried over unchanged so the port stays faithful; worth deciding separately.
