### PR TITLE
wifi: aic8800_sdio: fix Makefile Kconfig symbol

### DIFF
--- a/drivers/net/wireless/Makefile
+++ b/drivers/net/wireless/Makefile
@@ -4,7 +4,7 @@
 #
 
 obj-$(CONFIG_WLAN_VENDOR_ADMTEK) += admtek/
-obj-$(CONFIG_SPARD_WLAN_SUPPORT) += aic8800_sdio/
+obj-$(CONFIG_AIC_WLAN_SUPPORT) += aic8800_sdio/
 obj-$(CONFIG_WLAN_VENDOR_ATH) += ath/
 obj-$(CONFIG_WLAN_VENDOR_ATMEL) += atmel/
 obj-$(CONFIG_WLAN_VENDOR_BROADCOM) += broadcom/


### PR DESCRIPTION
## Summary

- gate the `aic8800_sdio` directory with the symbol defined by its Kconfig
- make the driver selectable and buildable through normal kernel configuration

## Verification

- `git diff --check`
- `scripts/checkpatch.pl --strict --no-tree drivers/net/wireless/Makefile`
- confirmed the Makefile and `aic8800_sdio/Kconfig` use `CONFIG_AIC_WLAN_SUPPORT`
- full ARM64 kernel build and board test were not run

Fixes #455