### PR TITLE
net: stmmac: fix dead Ethernet after suspend on RK3588 (backport the 6.15 phylink/stmmac resume ordering)

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -1260,6 +1260,8 @@ static int stmmac_phy_setup(struct stmmac_priv *priv)
 		priv->phylink_config.mac_capabilities &=
 			~(MAC_10HD | MAC_100HD | MAC_1000HD);
 	priv->phylink_config.mac_managed_pm = true;
+	/* Stmmac always requires an RX clock for hardware initialization */
+	priv->phylink_config.mac_requires_rxc = true;
 
 	phylink = phylink_create(&priv->phylink_config, fwnode,
 				 mode, &stmmac_phylink_mac_ops);
@@ -7842,16 +7844,12 @@ int stmmac_resume(struct device *dev)
 	}
 
 	rtnl_lock();
-	if (device_may_wakeup(priv->device) && priv->plat->pmt) {
-		phylink_resume(priv->phylink);
-	} else {
-		phylink_resume(priv->phylink);
-		if (device_may_wakeup(priv->device))
-			phylink_speed_up(priv->phylink);
-	}
-	rtnl_unlock();
 
-	rtnl_lock();
+	/* Prepare the PHY to resume, ensuring that its clocks which are
+	 * necessary for the MAC DMA reset to complete are running
+	 */
+	phylink_prepare_resume(priv->phylink);
+
 	mutex_lock(&priv->lock);
 
 	stmmac_reset_queues_param(priv);
@@ -7876,6 +7874,19 @@ int stmmac_resume(struct device *dev)
 	stmmac_enable_all_dma_irq(priv);
 
 	mutex_unlock(&priv->lock);
+
+	/* phylink_resume() must be called after the hardware has been
+	 * initialised because it may bring the link up immediately in a
+	 * workqueue thread, which will race with initialisation.
+	 */
+	if (device_may_wakeup(priv->device) && priv->plat->pmt) {
+		phylink_resume(priv->phylink);
+	} else {
+		phylink_resume(priv->phylink);
+		if (device_may_wakeup(priv->device))
+			phylink_speed_up(priv->phylink);
+	}
+
 	rtnl_unlock();
 
 	netif_device_attach(ndev);

--- a/drivers/net/phy/motorcomm.c
+++ b/drivers/net/phy/motorcomm.c
@@ -1168,6 +1168,25 @@ static int yt8531_config_init(struct phy_device *phydev)
 	return ret;
 }
 
+/*
+ * stmmac hard-resets the PHY on every resume (stmmac_mdio_reset() in
+ * stmmac_resume()) and, because it uses MAC-managed PM, phylib never
+ * calls phy_init_hw() again: the generic resume only clears BMCR_PDOWN and
+ * the extended registers stay at their power-on defaults (measured on an
+ * Orange Pi 5B: 0xa010 = 0x6bff, 0xa012 = 0xc8 after every rtcwake -m mem
+ * instead of what config_init wrote).  Redo the init before resuming.
+ */
+static int yt8531_resume(struct phy_device *phydev)
+{
+	int ret;
+
+	ret = yt8531_config_init(phydev);
+	if (ret < 0)
+		return ret;
+
+	return genphy_resume(phydev);
+}
+
 static struct phy_driver motorcomm_phy_drvs[] = {
 	{
 		PHY_ID_MATCH_EXACT(PHY_ID_YT8011),
@@ -1235,7 +1254,7 @@ static struct phy_driver motorcomm_phy_drvs[] = {
 		.features      = PHY_GBIT_FEATURES,
 		.config_init   = yt8531_config_init,
 		.suspend       = genphy_suspend,
-		.resume        = genphy_resume,
+		.resume        = yt8531_resume,
 #if (YTPHY_WOL_FEATURE_ENABLE)
 		.get_wol       = &ytphy_wol_feature_get,
 		.set_wol       = &ytphy_wol_feature_set,

--- a/drivers/net/phy/phylink.c
+++ b/drivers/net/phy/phylink.c
@@ -2021,6 +2021,31 @@ void phylink_suspend(struct phylink *pl, bool mac_wol)
 EXPORT_SYMBOL_GPL(phylink_suspend);
 
 /**
+ * phylink_prepare_resume() - prepare to resume a network device
+ * @pl: a pointer to a &struct phylink returned from phylink_create()
+ *
+ * Optional, but if called must be called prior to phylink_resume().
+ *
+ * Prepare to resume a network device, preparing the PHY as necessary.
+ */
+void phylink_prepare_resume(struct phylink *pl)
+{
+	struct phy_device *phydev = pl->phydev;
+
+	ASSERT_RTNL();
+
+	/* IEEE 802.3 22.2.4.1.5 allows PHYs to stop their receive clock
+	 * when PDOWN is set. However, some MACs require RXC to be running
+	 * in order to resume. If the MAC requires RXC, and we have a PHY,
+	 * then resume the PHY. Note that 802.3 allows PHYs 500ms before
+	 * the clock meets requirements. We do not implement this delay.
+	 */
+	if (pl->config->mac_requires_rxc && phydev && phydev->suspended)
+		phy_resume(phydev);
+}
+EXPORT_SYMBOL_GPL(phylink_prepare_resume);
+
+/**
  * phylink_resume() - handle a network device resume event
  * @pl: a pointer to a &struct phylink returned from phylink_create()
  *

--- a/include/linux/phylink.h
+++ b/include/linux/phylink.h
@@ -123,6 +123,9 @@ enum phylink_op_type {
  * @poll_fixed_state: if true, starts link_poll,
  *		      if MAC link is at %MLO_AN_FIXED mode.
  * @mac_managed_pm: if true, indicate the MAC driver is responsible for PHY PM.
+ * @mac_requires_rxc: if true, the MAC always requires a receive clock from PHY.
+ *                    The PHY driver should start the clock signal as soon as
+ *                    possible and avoid stopping it during suspend events.
  * @ovr_an_inband: if true, override PCS to MLO_AN_INBAND
  * @get_fixed_state: callback to execute to determine the fixed link state,
  *		     if MAC link is at %MLO_AN_FIXED mode.
@@ -136,6 +139,7 @@ struct phylink_config {
 	bool legacy_pre_march2020;
 	bool poll_fixed_state;
 	bool mac_managed_pm;
+	bool mac_requires_rxc;
 	bool ovr_an_inband;
 	void (*get_fixed_state)(struct phylink_config *config,
 				struct phylink_link_state *state);
@@ -581,6 +585,7 @@ void phylink_start(struct phylink *);
 void phylink_stop(struct phylink *);
 
 void phylink_suspend(struct phylink *pl, bool mac_wol);
+void phylink_prepare_resume(struct phylink *pl);
 void phylink_resume(struct phylink *pl);
 
 void phylink_ethtool_get_wol(struct phylink *, struct ethtool_wolinfo *);


### PR DESCRIPTION
Fixes #547.

After a suspend to RAM of more than about a minute, wired Ethernet on RK3588 boards often never comes back (link stays down until the PHY is hard-reset). `stmmac_resume()` starts phylink before `stmmac_hw_setup()` soft-resets the MAC, so the PHY state machine's first `MII_ADVERTISE` read-modify-write can hit the MDIO block mid-reset: the read returns 0 and the advertisement is written back as `0x0de0` (selector field cleared), and autonegotiation never completes. Details and the userspace proof are in #547.

This is the upstream fix from 6.15 backported to the 6.1 vendor tree:

1. **net: phylink: add phylink_prepare_resume()** — backport of 367f1854d442 plus the `mac_requires_rxc` config flag it keys on.
2. **net: stmmac: resume the PHY before, and start phylink after, the MAC setup** — backport of ef43e513, adapted to 6.1's two-branch `phylink_resume()` call: `phylink_prepare_resume()` keeps the PHY's RX clock running for the DMA reset (the reason the early `phylink_resume()` existed, 36d18b5664ef), and `phylink_resume()` moves after the hardware initialisation.
3. **net: phy: motorcomm: YT8531 - redo the init on resume** — found on the way: stmmac hard-resets the PHY on every resume (`stmmac_mdio_reset()`) and, with MAC-managed PM, nothing re-runs `config_init()`, so the YT8531's extended registers (0xa010/0xa012) sit at power-on defaults after the first suspend. Independent of the race; harmless to take separately.

Measured on an Orange Pi 5B (RK3588S, gmac1 + YT8531), same code as rkr7.2 in these paths:
- before: 11 of 21 sleeps ≥ 90 s woke with a dead link (`ANAR = 0x0de0`)
- after: 7 of 7 wakes clean (116 s to 10 min), link up on its own within 3 s at 1 Gbps, `ANAR = 0x1de1`

Applies cleanly on `rk-6.1-rkr7.2` (and rkr5.1). Compile-tested on 6.1.75 with an RK3588 config, no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
